### PR TITLE
Issue #3 JdkRequest now handles duplicate headers

### DIFF
--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -102,7 +102,7 @@ public final class JdkRequest implements Request {
                 conn.setUseCaches(false);
                 conn.setInstanceFollowRedirects(false);
                 for (final Map.Entry<String, String> header : headers) {
-                    conn.setRequestProperty(header.getKey(), header.getValue());
+                    conn.addRequestProperty(header.getKey(), header.getValue());
                 }
                 if (method.equals(Request.POST) || method.equals(Request.PUT)
                     || method.equals(Request.PATCH)) {

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -70,11 +70,8 @@ public final class MkContainerTest {
     /**
      * MkContainer can understand duplicate headers.
      * @throws Exception If something goes wrong inside
-     * @todo #1 Grizzly container doesn't understand same-name
-     *  headers, or we don't fetch them correctly from GrizzlyRequest
      */
     @Test
-    @org.junit.Ignore
     public void understandsDuplicateHeaders() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
             .next(new MkAnswer.Simple(""))


### PR DESCRIPTION
The test works fine as it is; I discovered the bug when I tried changing the type to `ApacheRequest` and it passed.

The difference is that `setRequestProperty` overrides the existing header while `addRequestProperty` appends to it. See [javadoc for URLConnection](http://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html#setRequestProperty%28java.lang.String, java.lang.String%29).
