### PR TITLE
#82 FakeRequest doesn't allow to return different body depending on the url

### DIFF
--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -58,8 +58,8 @@ import lombok.EqualsAndHashCode;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
- * @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @since 0.9
+ * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 @Immutable
 @EqualsAndHashCode(of = { "base", "code", "phrase", "hdrs", "content" })
@@ -169,7 +169,8 @@ public final class FakeRequest implements Request {
         this.code = status;
         this.phrase = reason;
         this.hdrs = new Array<Map.Entry<String, String>>(headers);
-        this.content = bodies;
+        this.content = new ConcurrentHashMap<Pattern, byte[]>(bodies.size());
+        this.content.putAll(bodies);
     }
 
     @Override
@@ -334,7 +335,7 @@ public final class FakeRequest implements Request {
         byte[] res = FakeRequest.EMPTY_BYTE_ARRAY;
         for (final Map.Entry<Pattern, byte[]> entry : this.content.entrySet()) {
             if (entry.getKey().matcher(url).matches()) {
-                res =  entry.getValue();
+                res = entry.getValue();
                 break;
             }
         }

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -38,6 +38,7 @@ import com.jcabi.http.RequestURI;
 import com.jcabi.http.Response;
 import com.jcabi.http.Wire;
 import com.jcabi.immutable.Array;
+import com.jcabi.immutable.ArrayMap;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -118,7 +119,7 @@ public final class FakeRequest implements Request {
     /**
      * Content received.
      */
-    private final transient Map<Pattern, byte[]> content;
+    private final transient ArrayMap<Pattern, byte[]> content;
 
     /**
      * Public ctor.
@@ -169,8 +170,7 @@ public final class FakeRequest implements Request {
         this.code = status;
         this.phrase = reason;
         this.hdrs = new Array<Map.Entry<String, String>>(headers);
-        this.content = new ConcurrentHashMap<Pattern, byte[]>(bodies.size());
-        this.content.putAll(bodies);
+        this.content = new ArrayMap<Pattern, byte[]>(bodies);
     }
 
     @Override

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -153,12 +153,11 @@ public final class FakeRequestTest {
     }
 
     /**
-     * FakeRequest returns the Response Body
-     *  if the matching Request Body is set.
+     * FakeRequest can return matching Response body
      * @throws Exception If something goes wrong inside.
      */
     @Test
-    public void fakeRequestReturnsMatchingResponseBody() throws Exception {
+    public void returnsMatchingResponseBody() throws Exception {
         final String[] responses = {"the response 1", "the response 2"};
         final String[] urls = {"^/first.*", "^/second.*"};
         final String request = "the request";

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -152,4 +152,28 @@ public final class FakeRequestTest {
         );
     }
 
+    /**
+     * FakeRequest returns the Response Body
+     *  if the matching Request Body is set.
+     * @throws Exception If something goes wrong inside.
+     */
+    @Test
+    public void fakeRequestReturnsMatchingResponseBody() throws Exception {
+        final String[] responses = {"the response 1", "the response 2"};
+        final String[] urls = {"^/first.*", "^/second.*"};
+        final String request = "the request";
+        final Request req =  new FakeRequest()
+            .withBody(urls[0], responses[0])
+            .withBody(urls[1], responses[1]);
+        req.uri().set(new URI("/first/path")).back()
+            .body().set(request).back()
+            .fetch()
+            .as(RestResponse.class)
+            .assertBody(Matchers.is(responses[0]));
+        req.uri().set(new URI("/second/path")).back()
+            .body().set(request).back()
+            .fetch()
+            .as(RestResponse.class)
+            .assertBody(Matchers.is(responses[1]));
+    }
 }

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -153,7 +153,7 @@ public final class FakeRequestTest {
     }
 
     /**
-     * FakeRequest can return matching Response body
+     * FakeRequest can return matching Response body.
      * @throws Exception If something goes wrong inside.
      */
     @Test


### PR DESCRIPTION
For #82 

* created new methods FakeRequest.withBody() allow use different bodies depending on the url for the response
* added new tests