### PR TITLE
Fixes #100: update optional dependecies

### DIFF
--- a/src/site/apt/optional-dependencies.apt.vm
+++ b/src/site/apt/optional-dependencies.apt.vm
@@ -22,8 +22,8 @@ Optional Dependencies
 +--
 <dependency>
   <groupId>com.sun.jersey</groupId>
-  <artifactId>jersey-core</artifactId>
-  <version>1.18.1</version>
+  <artifactId>jersey-client</artifactId>
+  <version>1.19</version>
 </dependency>
 +--
 


### PR DESCRIPTION
Fixes #100 

The optional dependency `jersey-core` does help in using the `uri()` method.

`jersey-client` does work.