### PR TITLE
Fix for issue #85 RequestBody.BaseBody.formParam append extra & at th…

### DIFF
--- a/src/test/java/com/jcabi/http/request/BaseRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/BaseRequestTest.java
@@ -114,4 +114,13 @@ public final class BaseRequestTest {
         );
     }
 
+    /**
+     * BaseRequest should not contains extra "&" at at the last name value pair.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void notContainsExtraChar() throws Exception {
+        final Wire wire = Mockito.mock(Wire.class);
+    }
+
 }


### PR DESCRIPTION
Fix for issue RequestBody.BaseBody.formParam append extra '&' at the end of last request parameter #85

Problem definition:
RequestBody.BaseBody.formParam() now always appends '&' at the end of every name-value pair of form parameters. However, there should be no '&' at the last name value pair (after call "back()"). 

Fix contains:
droping out the extra '&' when calling back() method. No other logic is changed

@dmarkov please init review. Thanks. 