### PR TITLE
Fix an issue with trailing ampersand

### DIFF
--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -483,13 +483,27 @@ final class BaseRequest implements Request {
          */
         private final transient BaseRequest owner;
         /**
+         * URL form character to prepend.
+         */
+        private final transient String prepend;
+        /**
          * Public ctor.
          * @param req Request
          * @param body Text to encapsulate
          */
         BaseBody(final BaseRequest req, final byte[] body) {
+            this(req, body, "");
+        }
+        /**
+         * Public ctor.
+         * @param req Request
+         * @param body Text to encapsulate
+         * @param pre Character to prepend
+         */
+        BaseBody(final BaseRequest req, final byte[] body, final String pre) {
             this.owner = req;
             this.text = body.clone();
+            this.prepend = pre;
         }
         @Override
         public String toString() {
@@ -534,6 +548,7 @@ final class BaseRequest implements Request {
                 return new BaseRequest.BaseBody(
                     this.owner,
                     new StringBuilder(this.get())
+                        .append(this.prepend)
                         .append(name)
                         .append('=')
                         .append(
@@ -542,9 +557,9 @@ final class BaseRequest implements Request {
                                 BaseRequest.ENCODING
                             )
                         )
-                        .append('&')
                         .toString()
-                        .getBytes(BaseRequest.CHARSET)
+                        .getBytes(BaseRequest.CHARSET),
+                    "&"
                 );
             } catch (final UnsupportedEncodingException ex) {
                 throw new IllegalStateException(ex);

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -203,7 +203,7 @@ public final class RequestTest {
     }
 
     /**
-     * BaseRequest can fetch body with HTTP POST request with params
+     * BaseRequest can fetch body with HTTP POST request with params.
      * @throws Exception If something goes wrong inside
      */
     @Test

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -197,11 +197,43 @@ public final class RequestTest {
         final MkQuery query = container.take();
         MatcherAssert.assertThat(
             URLDecoder.decode(query.body(), CharEncoding.UTF_8),
-            Matchers.containsString(value)
+            Matchers.is(String.format("p=%s", value))
         );
         container.stop();
     }
 
+    /**
+     * BaseRequest can fetch body with HTTP POST request with params
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void sendsTextWithPostRequestMatchMultipleParams() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer().next(
+            new MkAnswer.Simple("")
+        ).start();
+        final String value = "some value of \u20ac param \"&^%*;'\"";
+        final String follow = "other value of \u20ac param \"&^%*;'\"";
+        this.request(container.home())
+            .method(Request.POST)
+            .body()
+            .formParam("a", value)
+            .formParam("b", follow)
+            .back()
+            .header(
+                HttpHeaders.CONTENT_TYPE,
+                MediaType.APPLICATION_FORM_URLENCODED
+            )
+            .fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK);
+        final MkQuery query = container.take();
+        MatcherAssert.assertThat(
+            URLDecoder.decode(query.body(), CharEncoding.UTF_8),
+            Matchers.is(
+                String.format("a=%s&b=%s", value, follow)
+            )
+        );
+        container.stop();
+    }
     /**
      * BaseRequest can fetch body with HTTP POST request.
      * @throws Exception If something goes wrong inside


### PR DESCRIPTION
I've noticed that a single `.formParam()` also appending a `&` for the next parameter, it should really be prepending from the second parameter.