### PR TITLE
#96 MkContainer extends Closeable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,13 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/main/java/com/jcabi/http/mock/MkContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkContainer.java
@@ -29,6 +29,7 @@
  */
 package com.jcabi.http.mock;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
@@ -58,6 +59,9 @@ import org.hamcrest.Matcher;
  * and works until JVM is shut down. The only way to stop it is to call
  * {@link #stop()}.
  *
+ * <p>Since version 0.11 container implements {@link Closeable} and can be
+ * used in try-with-resource block.
+ *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
@@ -65,7 +69,7 @@ import org.hamcrest.Matcher;
  * @checkstyle TooManyMethods (200 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public interface MkContainer {
+public interface MkContainer extends Closeable {
 
     /**
      * Give this answer on the next request.

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
@@ -147,20 +147,21 @@ public final class MkGrizzlyContainer implements MkContainer {
         );
     }
 
+    @Override
+    public void close() {
+        this.stop();
+    }
+
     /**
      * Reserve port.
      * @return Reserved TCP port
      * @throws IOException If fails
      */
     private static int reserve() throws IOException {
-        int reserved;
-        final ServerSocket socket = new ServerSocket(0);
-        try {
+        final int reserved;
+        try (final ServerSocket socket = new ServerSocket(0)) {
             reserved = socket.getLocalPort();
-        } finally {
-            socket.close();
         }
         return reserved;
     }
-
 }


### PR DESCRIPTION
#96 `MkContainer` extends `Closeable` now
Compilation source and target versions were risen up to 1.7 (as according to README we support Java 7 and higher)