### PR TITLE
Pull request for issue #121

### DIFF
--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -92,14 +92,14 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
         final InputStream content, final int connect, final int read
     ) throws IOException {
         final Response rsp;
-        if (!method.equals(Request.GET)
-            || (method.equals(Request.GET) && this.requestHasCmcHeader(headers))
+        if (method.equals(Request.GET)
+            && !this.requestHasCmcHeader(headers)
         ) {
-            rsp = this.origin.send(
+            rsp = this.consultCache(
                 req, home, method, headers, content, connect, read
             );
         } else {
-            rsp = this.consultCache(
+            rsp = this.origin.send(
                 req, home, method, headers, content, connect, read
             );
         }

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -92,7 +92,14 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
         final InputStream content, final int connect, final int read
     ) throws IOException {
         final Response rsp;
-        if (method.equals(Request.GET)) {
+        boolean requestHasCmch = false;
+        for (final Map.Entry<String, String> header : headers) {
+            if (header.getKey().equals(this.cmch)) {
+                requestHasCmch = true;
+                break;
+            }
+        }
+        if (method.equals(Request.GET) && !requestHasCmch) {
             rsp = this.consultCache(
                 req, home, method, headers, content, connect, read
             );

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -92,9 +92,7 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
         final InputStream content, final int connect, final int read
     ) throws IOException {
         final Response rsp;
-        if (method.equals(Request.GET)
-            && !this.requestHasCmcHeader(headers)
-        ) {
+        if (method.equals(Request.GET) && !this.requestHasCmcHeader(headers)) {
             rsp = this.consultCache(
                 req, home, method, headers, content, connect, read
             );

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -92,17 +92,23 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
         final InputStream content, final int connect, final int read
     ) throws IOException {
         final Response rsp;
-        boolean requestHasCmch = false;
-        for (final Map.Entry<String, String> header : headers) {
-            if (header.getKey().equals(this.cmch)) {
-                requestHasCmch = true;
-                break;
+        if (method.equals(Request.GET)) {
+            boolean requestHasCmch = false;
+            for (final Map.Entry<String, String> header : headers) {
+                if (header.getKey().equals(this.cmch)) {
+                    requestHasCmch = true;
+                    break;
+                }
             }
-        }
-        if (method.equals(Request.GET) && !requestHasCmch) {
-            rsp = this.consultCache(
-                req, home, method, headers, content, connect, read
-            );
+            if (requestHasCmch) {
+                rsp = this.origin.send(
+                    req, home, method, headers, content, connect, read
+                );
+            } else {
+                rsp = this.consultCache(
+                    req, home, method, headers, content, connect, read
+                );
+            }
         } else {
             rsp = this.origin.send(
                 req, home, method, headers, content, connect, read

--- a/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
@@ -35,8 +35,6 @@ import javax.ws.rs.core.HttpHeaders;
 /**
  * Wire that caches requests based on Last-Modified
  * and If-Modified-Since headers.
- * @todo #90:30min If the original request already has an If-Modified-Since
- *  header it should be sent directly.
  * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
  * @version $Id$
  * @since 1.15

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -184,7 +184,7 @@ public final class LastModifiedCachingWireTest {
         }
     }
     /**
-     * LastModifiedCachingWire can send request directly,
+     * LastModifiedCachingWire can send a request directly
      * if it contains the "If-Modified-Since" header.
      * @throws Exception - if the test fails
      */
@@ -195,7 +195,8 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK, LastModifiedCachingWireTest.BODY
                 )
-            ).next(
+            )
+            .next(
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK, LastModifiedCachingWireTest.BODY
                 )

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -184,7 +184,7 @@ public final class LastModifiedCachingWireTest {
         }
     }
     /**
-     * LastModifiedCachingWire sends request directly,
+     * LastModifiedCachingWire can send request directly,
      * if it contains the "If-Modified-Since" header.
      * @throws Exception - if the test fails
      */
@@ -207,7 +207,7 @@ public final class LastModifiedCachingWireTest {
                     HttpHeaders.IF_MODIFIED_SINCE,
                     "Fri, 01 Jan 2016 00:00:00 GMT"
                 );
-            for (int idx = 0; idx < 2; idx = idx + 1) {
+            for (int idx = 0; idx < 2; ++idx) {
                 req.fetch().as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -207,10 +207,14 @@ public final class LastModifiedCachingWireTest {
                     HttpHeaders.IF_MODIFIED_SINCE,
                     "Fri, 01 Jan 2016 00:00:00 GMT"
                 );
-            req.fetch().as(RestResponse.class)
-                .assertStatus(HttpURLConnection.HTTP_OK)
-                .assertBody(Matchers.equalTo(LastModifiedCachingWireTest.BODY));
-            MatcherAssert.assertThat(container.queries(), Matchers.equalTo(1));
+            for (int idx = 0; idx < 2; idx = idx + 1) {
+                req.fetch().as(RestResponse.class)
+                    .assertStatus(HttpURLConnection.HTTP_OK)
+                    .assertBody(
+                        Matchers.equalTo(LastModifiedCachingWireTest.BODY)
+                );
+            }
+            MatcherAssert.assertThat(container.queries(), Matchers.equalTo(2));
         } finally {
             container.stop();
         }


### PR DESCRIPTION
This is the PR for issue #121 .

If a GET request is sent through an ``AbstractHeaderBasedCachingWire`` (e.g. ``LastModifiedCachingWire``, ``ETagCachingWire``) and it contains the Client Modification Check header (``cmch``) specified in the ``Wire``, then it will be sent directly without being cached. 
E.g. The ``cmch`` of ``LastModifiedCachingWire`` is "If-Modified-Since": if you send a request containing
this header, through ``LastModifiedCachingWire``, it will be sent directly without being cached.