### PR TITLE
Solve #120 Evict cache entry if If-Modified-Since request responded

### DIFF
--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -139,7 +139,6 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
 
     /**
      * Check response and update cache or evict from cache if needed.
-     *  with HTTP_OK code and no Last-Modified header.
      * @param req Request
      * @param home URI to fetch
      * @param method HTTP method

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -138,8 +138,7 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
     }
 
     /**
-     * Check response and update cache if needed.
-     * @todo #90:30min Evict cache entry if If-Modified-Since request responded
+     * Check response and update cache or evict from cache if needed.
      *  with HTTP_OK code and no Last-Modified header.
      * @param req Request
      * @param home URI to fetch
@@ -173,13 +172,17 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
     }
 
     /**
-     * Add response to cache.
+     * Add response to cache,
+     * Update response in cache or
+     * Evict response from cache.
      * @param req The request to be used as key
      * @param rsp The response to add
      */
     private void updateCache(final Request req, final Response rsp) {
         if (rsp.headers().containsKey(this.scvh)) {
             this.cache.put(req, rsp);
+        } else {
+            this.cache.remove(req);
         }
     }
 

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -178,7 +178,7 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
     private void updateCache(final Request req, final Response rsp) {
         if (rsp.headers().containsKey(this.scvh)) {
             this.cache.put(req, rsp);
-        } else {
+        } else if (rsp.status() == HttpURLConnection.HTTP_OK) {
             this.cache.remove(req);
         }
     }

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -171,11 +171,9 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
     }
 
     /**
-     * Add response to cache,
-     * Update response in cache or
-     * Evict response from cache.
+     * Add, update or evict response in cache.
      * @param req The request to be used as key
-     * @param rsp The response to add
+     * @param rsp The response to add/update
      */
     private void updateCache(final Request req, final Response rsp) {
         if (rsp.headers().containsKey(this.scvh)) {

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -61,7 +61,10 @@ public final class LastModifiedCachingWireTest {
      * Test body.
      * @todo #120:15min Clean tests shared fields and redundant variables
      *  Move constants in this file to their tests because tests must share
-     *  nothing. Then also inline any redundant variables. See:
+     *  nothing. Then also inline any redundant variables.
+     *  Please also configure pdd and est in.travis.yml as done e.g. in
+     *  https://github.com/jcabi/jcabi-xml/blob/master/.travis.yml
+     *  For first points explanation, read:
      *  http://www.yegor256.com/2016/05/03/test-methods-must-share-nothing.html
      *  http://www.yegor256.com/2015/09/01/redundant-variables-are-evil.html
      * */
@@ -205,10 +208,19 @@ public final class LastModifiedCachingWireTest {
     /**
      * LastModifiedCachingWire can resist cache eviction in the event of a non
      * OK response without a last modified header.
+     * @todo #120:30min Confirm cache clearing behaviour in all non-OK responses
+     *  Non-OK behaviour was not specified in #120, so for example, if the
+     *  response is 404 as below, does it make any sense to keep the item in
+     *  cache? Is it likely a server will respond 404, and then later the exact
+     *  unmodified content is available again. I think they all need to be
+     *  thought about, another dubious response might be 301 Moved Permanently,
+     *  or 410 Gone etc. Or, personally I think all non-OK and OK responses
+     *  should behave the same WRT to clearing the cache as the cache value is
+     *  so unlikely to be returned in future.
      * @throws Exception If fails
      */
     @Test
-    public void doesNotEvictCacheGetRequestOnNonOK()
+    public void doesNotEvictCacheOnNonOK()
         throws Exception {
         final String body = "Body";
         final MkContainer container = new MkGrizzlyContainer()

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -204,7 +204,7 @@ public final class LastModifiedCachingWireTest {
 
     /**
      * LastModifiedCachingWire can resist cache eviction in the event of a non
-     * OK response.
+     * OK response without a last modified header.
      * @throws Exception If fails
      */
     @Test

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -135,8 +135,8 @@ public final class LastModifiedCachingWireTest {
     }
 
     /**
-     * Must evict any previous cached entry if a new entry does not have a last
-     * modified header.
+     * LastModifiedCachingWire can evict any previous cached entry if a new
+     * response does not have a last modified header.
      * We can observe this via the If-Modified-Since headers as when the cache
      * does not contain an entry, this is not present on the request.
      * @throws Exception If fails

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -59,7 +59,7 @@ public final class LastModifiedCachingWireTest {
 
     /**
      * Test body.
-     * @todo: #120:15min Clean tests shared fields and redundant variables
+     * @todo #120:15min Clean tests shared fields and redundant variables
      *  Move constants in this file to their tests because tests must share
      *  nothing. Then also inline any redundant variables. See:
      *  http://www.yegor256.com/2016/05/03/test-methods-must-share-nothing.html

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -59,18 +59,15 @@ public final class LastModifiedCachingWireTest {
 
     /**
      * Test body.
+     * @todo: #120 inline constant to test(s)
      * */
     private static final String BODY = "Test body";
 
     /**
      * Test body updated.
+     * @todo: #120 inline constant to test(s)
      * */
     private static final String BODY_UPDATED = "Test body updated";
-
-    /**
-     * Test body updated 2.
-     * */
-    private static final String BODY_UPDATED_2 = "Test body updated 2";
 
     /**
      * LastModifiedCachingWire can handle requests without headers.
@@ -147,6 +144,9 @@ public final class LastModifiedCachingWireTest {
     @Test
     public void doesNotCacheGetRequestIfTheLastModifiedHeaderIsMissing()
         throws Exception {
+        final String firstresponse = "Body 1";
+        final String secondresponse = "Body 2";
+        final String thirdreponse = "Body 3";
         final Map<String, String> headers = Collections.singletonMap(
                 HttpHeaders.LAST_MODIFIED,
                 "Wed, 15 Nov 1995 05:58:08 GMT"
@@ -157,7 +157,7 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
                     headers.entrySet(),
-                    LastModifiedCachingWireTest.BODY.getBytes()
+                    firstresponse.getBytes()
                 ),
                 Matchers.not(queryContainsIfModifiedSinceHeader())
             )
@@ -165,7 +165,7 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
                     noHeaders.entrySet(),
-                    LastModifiedCachingWireTest.BODY_UPDATED.getBytes()
+                    secondresponse.getBytes()
                 ),
                 queryContainsIfModifiedSinceHeader()
             )
@@ -173,7 +173,7 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
                     noHeaders.entrySet(),
-                    LastModifiedCachingWireTest.BODY_UPDATED_2.getBytes()
+                    thirdreponse.getBytes()
                 ),
                 Matchers.not(queryContainsIfModifiedSinceHeader())
             ).start();
@@ -183,17 +183,17 @@ public final class LastModifiedCachingWireTest {
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(LastModifiedCachingWireTest.BODY)
+                    Matchers.equalTo(firstresponse)
             );
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(LastModifiedCachingWireTest.BODY_UPDATED)
+                    Matchers.equalTo(secondresponse)
             );
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(LastModifiedCachingWireTest.BODY_UPDATED_2)
+                    Matchers.equalTo(thirdreponse)
             );
         } finally {
             container.stop();

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -59,13 +59,14 @@ public final class LastModifiedCachingWireTest {
 
     /**
      * Test body.
-     * @todo: #120 inline constant to test(s)
+     * @todo: #120 move constants in this file to their tests because tests
+     *  must share nothing
+     *  http://www.yegor256.com/2016/05/03/test-methods-must-share-nothing.html
      * */
     private static final String BODY = "Test body";
 
     /**
      * Test body updated.
-     * @todo: #120 inline constant to test(s)
      * */
     private static final String BODY_UPDATED = "Test body updated";
 
@@ -95,6 +96,8 @@ public final class LastModifiedCachingWireTest {
 
     /**
      * LastModifiedCachingWire can cache GET requests.
+     * @todo: #120 inline redundant "headers" variable
+     *  see http://www.yegor256.com/2015/09/01/redundant-variables-are-evil.html
      * @throws Exception If fails
      */
     @Test
@@ -144,20 +147,19 @@ public final class LastModifiedCachingWireTest {
     @Test
     public void doesNotCacheGetRequestIfTheLastModifiedHeaderIsMissing()
         throws Exception {
-        final String firstresponse = "Body 1";
-        final String secondresponse = "Body 2";
-        final String thirdreponse = "Body 3";
-        final Map<String, String> headers = Collections.singletonMap(
-                HttpHeaders.LAST_MODIFIED,
-                "Wed, 15 Nov 1995 05:58:08 GMT"
-        );
+        final String first = "Body 1";
+        final String second = "Body 2";
+        final String third = "Body 3";
         final Map<String, String> noHeaders = Collections.emptyMap();
         final MkContainer container = new MkGrizzlyContainer()
             .next(
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
-                    headers.entrySet(),
-                    firstresponse.getBytes()
+                    Collections.singletonMap(
+                            HttpHeaders.LAST_MODIFIED,
+                            "Wed, 15 Nov 1995 05:58:08 GMT"
+                    ).entrySet(),
+                    first.getBytes()
                 ),
                 Matchers.not(queryContainsIfModifiedSinceHeader())
             )
@@ -165,7 +167,7 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
                     noHeaders.entrySet(),
-                    secondresponse.getBytes()
+                    second.getBytes()
                 ),
                 queryContainsIfModifiedSinceHeader()
             )
@@ -173,7 +175,7 @@ public final class LastModifiedCachingWireTest {
                 new MkAnswer.Simple(
                     HttpURLConnection.HTTP_OK,
                     noHeaders.entrySet(),
-                    thirdreponse.getBytes()
+                    third.getBytes()
                 ),
                 Matchers.not(queryContainsIfModifiedSinceHeader())
             ).start();
@@ -183,17 +185,17 @@ public final class LastModifiedCachingWireTest {
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(firstresponse)
+                    Matchers.equalTo(first)
             );
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(secondresponse)
+                    Matchers.equalTo(second)
             );
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
-                    Matchers.equalTo(thirdreponse)
+                    Matchers.equalTo(third)
             );
         } finally {
             container.stop();
@@ -310,8 +312,7 @@ public final class LastModifiedCachingWireTest {
         return new BaseMatcher<MkQuery>() {
             @Override
             public boolean matches(final Object object) {
-                final MkQuery query = (MkQuery) object;
-                return query.headers().containsKey(header);
+                return ((MkQuery) object).headers().containsKey(header);
             }
             @Override
             public void describeTo(final Description description) {


### PR DESCRIPTION
#120

Issue: Evict cache entry if `If-Modified-Since` request responded with `HTTP_OK` code and no `Last-Modified` header

Changes: Add test to expose problem, remove cache when no `Last-Modified` header