### PR TITLE
Enhanced the API to support mulripart form body + added todo puzzle

### DIFF
--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -129,6 +129,12 @@ public interface Request {
     RequestBody body();
 
     /**
+     * Get multipart form (multipart/form-data) body.
+     * @return New altered request
+     */
+    RequestBody multipartBody();
+
+    /**
      * Set request header.
      * @param name ImmutableHeader name
      * @param value Value of the header to set

--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -236,6 +236,11 @@ public final class ApacheRequest implements Request {
     }
 
     @Override
+    public RequestBody multipartBody() {
+        return this.base.multipartBody();
+    }
+
+    @Override
     public Request method(final String method) {
         return this.base.method(method);
     }

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -66,11 +66,14 @@ import lombok.EqualsAndHashCode;
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @see Request
  * @see Response
- * @todo #87:30min Refactor this class to get rid of PMD.GodClass (and possibly
- *  also PMD.TooManyMethods). This can be done if MultiPartFormBody and
+ * @todo #87:30min Refactor this class to get rid of PMD.GodClass.
+ *  This can be done if MultiPartFormBody and
  *  FormEncodedBody are pulled out. Also, the two
  *  share the same implementations for all methods besides formParam,
  *  so they can be refactored to extend an AbstractRequestBody.
+ *  PMD.TooManyMethods might come together with getting rid of the
+ *  first one, since maybe qulice is counting the methods in the inner
+ *  classes too - if it doesn't, then it can be left.
  */
 @Immutable
 @EqualsAndHashCode(of = { "home", "mtd", "hdrs", "content" })

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -66,6 +66,11 @@ import lombok.EqualsAndHashCode;
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @see Request
  * @see Response
+ * @todo #87:30min Refactor this class to get rid of PMD.GodClass (and possibly
+ *  also PMD.TooManyMethods). This can be done if MultiPartFormBody and
+ *  FormEncodedBody are pulled out. Also, the two
+ *  share the same implementations for all methods besides formParam,
+ *  so they can be refactored to extend an AbstractRequestBody.
  */
 @Immutable
 @EqualsAndHashCode(of = { "home", "mtd", "hdrs", "content" })
@@ -468,11 +473,13 @@ final class BaseRequest implements Request {
      *  enctype multipart/form-data.
      */
     private static final class MultipartFormBody implements RequestBody {
+
         /**
          * Content encapsulated.
          */
         @Immutable.Array
         private final transient byte[] text;
+
         /**
          * Base request encapsulated.
          */
@@ -487,10 +494,12 @@ final class BaseRequest implements Request {
             this.owner = req;
             this.text = body.clone();
         }
+
         @Override
         public String toString() {
             return new RequestBody.Printable(this.text).toString();
         }
+
         @Override
         public Request back() {
             return new BaseRequest(
@@ -501,28 +510,34 @@ final class BaseRequest implements Request {
                 this.text
             );
         }
+
         @Override
         public String get() {
             return new String(this.text, BaseRequest.CHARSET);
         }
+
         @Override
         public RequestBody set(final String txt) {
             return this.set(txt.getBytes(BaseRequest.CHARSET));
         }
+
         @Override
         public RequestBody set(final JsonStructure json) {
             final StringWriter writer = new StringWriter();
             Json.createWriter(writer).write(json);
             return this.set(writer.toString());
         }
+
         @Override
         public RequestBody set(final byte[] txt) {
             return new BaseRequest.FormEncodedBody(this.owner, txt);
         }
+
         @Override
         public RequestBody formParam(final String name, final Object value) {
             throw new UnsupportedOperationException("Method not available");
         }
+
         @Override
         public RequestBody formParams(final Map<String, String> params) {
             RequestBody body = this;
@@ -541,19 +556,23 @@ final class BaseRequest implements Request {
     @EqualsAndHashCode(of = "text")
     @Loggable(Loggable.DEBUG)
     private static final class FormEncodedBody implements RequestBody {
+
         /**
          * Content encapsulated.
          */
         @Immutable.Array
         private final transient byte[] text;
+
         /**
          * Base request encapsulated.
          */
         private final transient BaseRequest owner;
+
         /**
          * URL form character to prepend.
          */
         private final transient String prepend;
+
         /**
          * Public ctor.
          * @param req Request
@@ -562,6 +581,7 @@ final class BaseRequest implements Request {
         FormEncodedBody(final BaseRequest req, final byte[] body) {
             this(req, body, "");
         }
+
         /**
          * Public ctor.
          * @param req Request
@@ -575,10 +595,12 @@ final class BaseRequest implements Request {
             this.text = body.clone();
             this.prepend = pre;
         }
+
         @Override
         public String toString() {
             return new RequestBody.Printable(this.text).toString();
         }
+
         @Override
         public Request back() {
             return new BaseRequest(
@@ -589,24 +611,29 @@ final class BaseRequest implements Request {
                 this.text
             );
         }
+
         @Override
         public String get() {
             return new String(this.text, BaseRequest.CHARSET);
         }
+
         @Override
         public RequestBody set(final String txt) {
             return this.set(txt.getBytes(BaseRequest.CHARSET));
         }
+
         @Override
         public RequestBody set(final JsonStructure json) {
             final StringWriter writer = new StringWriter();
             Json.createWriter(writer).write(json);
             return this.set(writer.toString());
         }
+
         @Override
         public RequestBody set(final byte[] txt) {
             return new BaseRequest.FormEncodedBody(this.owner, txt);
         }
+
         @Override
         public RequestBody formParam(final String name, final Object value) {
             try {
@@ -630,6 +657,7 @@ final class BaseRequest implements Request {
                 throw new IllegalStateException(ex);
             }
         }
+
         @Override
         public RequestBody formParams(final Map<String, String> params) {
             RequestBody body = this;
@@ -638,6 +666,7 @@ final class BaseRequest implements Request {
             }
             return body;
         }
+
     }
 
 }

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -177,6 +177,11 @@ public final class FakeRequest implements Request {
     }
 
     @Override
+    public RequestBody multipartBody() {
+        return this.base.multipartBody();
+    }
+
+    @Override
     public Request method(final String method) {
         return this.base.method(method);
     }

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -254,6 +254,11 @@ public final class JdkRequest implements Request {
     }
 
     @Override
+    public RequestBody multipartBody() {
+        return this.base.multipartBody();
+    }
+
+    @Override
     public Request method(final String method) {
         return this.base.method(method);
     }


### PR DESCRIPTION
This is for issue #87 .

Added `BaseRequest.MultipartFormBody` implementation of `RequestBody`, that adds the given form parameters to the body in `multipart/form-data` enctype. There is a todo puzzle for implementation and unit testing of method `formParam`, since this task was broad enough and the changes already cover the requirement of extending the API.

Other changes done: 

1) Renamed `BaseRequest.BaseBody` to `BaseRequest.FormEncodedBody`. This is more appropriate, since that's what it is and it is no longer the single "base" body used. 

2) Added method `Request.multipartBody()` which should be used to add elements to the `multipart/form-data` formular. 

3) Added suppress warning for PMD.GodClass (BaseRequest), since pulling out the 2 `RequestBody` implementation means architectural change (`Request` then also needs to expose the wire, headers etc). 

**Usage**:

```
Request.method(Request.POST)
    .body()
    .formParam("firstName", "Mihai")
    .formParam("lastName", "Andronache")
    .back()
    .header(
        HttpHeaders.CONTENT_TYPE,
        MediaType.APPLICATION_FORM_URLENCODED
     )
    .fetch().as(RestResponse.class)
    .assertStatus(HttpURLConnection.HTTP_OK);
```

^ As until now, this is used when a simple `application/x-www-form-urlencoded` formular is sent, with no attachments.

```
Request.method(Request.POST)
    .multipartBody()
    .formParam("firstName", "Mihai")
    .formParam("lastName", "Andronache")
    .formParam("cv", new File("CV.pdf"))
    .back()
    .header(
        HttpHeaders.CONTENT_TYPE,
        MediaType.MULTIPART_FORM_DATA
     )
    .fetch().as(RestResponse.class)
    .assertStatus(HttpURLConnection.HTTP_OK);
```

^ And this is to be used when sending attachments (multipart/form-data encoded forms)
