### PR TITLE
In case of huge xml response OOM may occur 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-xml</artifactId>
-            <version>0.17.1</version>
+            <version>0.20</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/com/jcabi/http/response/XmlResponse.java
+++ b/src/main/java/com/jcabi/http/response/XmlResponse.java
@@ -41,7 +41,6 @@ import java.net.URI;
 import java.util.Map;
 import javax.xml.namespace.NamespaceContext;
 import lombok.EqualsAndHashCode;
-import org.hamcrest.MatcherAssert;
 
 /**
  * XML response.
@@ -131,14 +130,15 @@ public final class XmlResponse extends AbstractResponse {
      * @return This object
      */
     public XmlResponse assertXPath(final String xpath) {
-        MatcherAssert.assertThat(
-            String.format(
-                "XML doesn't contain required XPath '%s':%n%s",
-                xpath, this.body()
-            ),
-            this.body(),
-            XhtmlMatchers.hasXPath(xpath, this.context())
-        );
+        final String body = this.body();
+        if (!XhtmlMatchers.hasXPath(xpath, this.context()).matches(body)) {
+            throw new AssertionError(
+                String.format(
+                    "XML doesn't contain required XPath '%s':%n%s",
+                    xpath, body
+                )
+            );
+        }
         return this;
     }
 


### PR DESCRIPTION
Use lazy error message for such cases to reduce memory consumption