### PR TITLE
Fixed Javadocs

### DIFF
--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -65,10 +65,10 @@ import java.io.InputStream;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * <p>You can use either {@link ApacheRequest} or {@link JdkRequest},
- * according to your needs. {@link JdkRequest} won't require any additional
- * dependencies, while {@link ApacheRequest} will properly support all
- * possible HTTP methods ({@link JdkRequest} doesn't support {@code PATCH},
+ * <p>You can use either ApacheRequest or JdkRequest,
+ * according to your needs. JdkRequest won't require any additional
+ * dependencies, while ApacheRequest will properly support all
+ * possible HTTP methods (JdkRequest doesn't support {@code PATCH},
  * for example).
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)

--- a/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
@@ -45,7 +45,7 @@ public final class MkAnswerMatchers {
     }
 
     /**
-     * Matches the value of {@link MkAnswer#body()} against the given matcher.
+     * Matches the value of the MkAnswer's body against the given matcher.
      *
      * @param matcher The matcher to use.
      * @return Matcher for checking the body of MkAnswer
@@ -55,7 +55,7 @@ public final class MkAnswerMatchers {
     }
 
     /**
-     * Matches the value of {@link MkAnswer#bodyBytes()} against the given
+     * Matches the value of the MkAnswer's body bytes against the given
      * matcher.
      * @param matcher The matcher to use
      * @return Matcher for checking the body of MkAnswer
@@ -66,7 +66,7 @@ public final class MkAnswerMatchers {
     }
 
     /**
-     * Matches the content of {@link MkAnswer#header()} against the given
+     * Matches the content of the MkAnswer's header against the given
      * matcher. Note that for a valid match to occur, the header entry must
      * exist <i>and</i> its value(s) must match the given matcher.
      *

--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -46,7 +46,7 @@ public final class MkQueryMatchers {
     }
 
     /**
-     * Matches the value of {@link MkQuery#body()} against the given matcher.
+     * Matches the value of the MkQuery's body against the given matcher.
      *
      * @param matcher The matcher to use.
      * @return Matcher for checking the body of MkQuery
@@ -56,7 +56,7 @@ public final class MkQueryMatchers {
     }
 
     /**
-     * Matches the content of {@link MkQuery#header()} against the given
+     * Matches the content of the MkQuery's header against the given
      * matcher. Note that for a valid match to occur, the header entry must
      * exist <i>and</i> its value(s) must match the given matcher.
      *

--- a/src/main/java/com/jcabi/http/request/package-info.java
+++ b/src/main/java/com/jcabi/http/request/package-info.java
@@ -31,7 +31,7 @@
 /**
  * Requests.
  *
- * <p>This package contains implementations of class {@link Request}.
+ * <p>This package contains implementations of class Request.
  * The most popular and easy to use it {@link JdkRequest}.
  *
  * <p>However, in some situations {@link JdkRequest} falls short and


### PR DESCRIPTION
Fixes #173 
Changed some javadocs in order for the maven-javadoc-plugin to stop complaining about their format.