### PR TITLE
Add support for SSL Context per connection

### DIFF
--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -32,6 +32,7 @@ package com.jcabi.http;
 import com.jcabi.aspects.Immutable;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.net.ssl.SSLContext;
 
 /**
  * RESTful request.
@@ -78,7 +79,8 @@ import java.io.InputStream;
  * @see com.jcabi.http.request.ApacheRequest
  */
 @Immutable
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
+
 public interface Request {
 
     /**
@@ -164,6 +166,14 @@ public interface Request {
      * @return New alternated request
      */
     Request timeout(int connect, int read);
+
+    /**
+     * Use this SSL Context.
+     *
+     * @param context The SSL Context to use
+     * @return New alternated request
+     */
+    Request sslcontext(SSLContext context);
 
     /**
      * Execute it with a specified HTTP method.

--- a/src/main/java/com/jcabi/http/Wire.java
+++ b/src/main/java/com/jcabi/http/Wire.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 
 /**
  * Wire.
@@ -68,13 +69,15 @@ public interface Wire {
      * @param content HTTP body
      * @param connect The connect timeout
      * @param read The read timeout
+     * @param sslcontext SSL Context
      * @return Response obtained
      * @throws IOException if fails
      * @checkstyle ParameterNumber (6 lines)
      */
     Response send(Request req, String home, String method,
-        Collection<Map.Entry<String, String>> headers, InputStream content,
-        int connect, int read)
+                  Collection<Map.Entry<String, String>> headers,
+                  InputStream content, int connect, int read,
+                  SSLContext sslcontext)
         throws IOException;
 
 }

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -56,8 +56,8 @@ import java.util.LinkedList;
 import java.util.Map;
 import javax.json.Json;
 import javax.json.JsonStructure;
-import javax.ws.rs.core.HttpHeaders;
 import javax.net.ssl.SSLContext;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriBuilder;
 import lombok.EqualsAndHashCode;
 

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -45,6 +45,7 @@ import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -131,13 +132,14 @@ public final class FakeRequest implements Request {
         this.base = new BaseRequest(
             new Wire() {
                 @Override
-                // @checkstyle ParameterNumber (6 lines)
+                // @checkstyle ParameterNumber (7 lines)
                 public Response send(final Request req, final String home,
                     final String method,
                     final Collection<Map.Entry<String, String>> headers,
                     final InputStream text,
                     final int connect,
-                    final int read) {
+                    final int read,
+                    final SSLContext sslcontext) {
                     return new DefaultResponse(
                         req,
                         FakeRequest.this.code,
@@ -189,6 +191,11 @@ public final class FakeRequest implements Request {
     @Override
     public Request timeout(final int connect, final int read) {
         return this.base.timeout(connect, read);
+    }
+
+    @Override
+    public Request sslcontext(final SSLContext context) {
+        return this.base.sslcontext(context);
     }
 
     @Override

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -94,12 +94,11 @@ public final class JdkRequest implements Request {
             final SSLContext sslcontext) throws IOException {
             final URLConnection raw = new URL(home).openConnection();
             if (!(raw instanceof HttpURLConnection)) {
-                throw new IOException(
-                        String.format(
-                                "'%s' opens %s instead of expected HttpURLConnection",
-                                home, raw.getClass().getName()
-                        )
+                final String message = String.format(
+                        "'%s' opens %s instead of expected HttpURLConnection",
+                        home, raw.getClass().getName()
                 );
+                throw new IOException(message);
             }
             HttpURLConnection conn = null;
             try {
@@ -135,13 +134,14 @@ public final class JdkRequest implements Request {
                 }
             }
         }
-        // @checkstyle ParameterNumber (4 lines)
+        // @checkstyle ParameterNumber (5 lines)
+        // @checkstyle LineLengthCheck (4 lines)
         private HttpURLConnection createHttpUrlConnection(final URLConnection raw,
                                                           final int connect, final int read, final String method,
                                                           final Collection<Map.Entry<String, String>> headers,
                                                           final SSLContext sslcontext) throws IOException {
-
-            final HttpURLConnection conn = HttpURLConnection.class.cast(raw);
+            final HttpURLConnection conn =
+                    HttpURLConnection.class.cast(raw);
             conn.setConnectTimeout(connect);
             conn.setReadTimeout(read);
             conn.setRequestMethod(method);

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -92,10 +92,19 @@ public final class JdkRequest implements Request {
             final int connect,
             final int read,
             final SSLContext sslcontext) throws IOException {
+            final URLConnection raw = new URL(home).openConnection();
+            if (!(raw instanceof HttpURLConnection)) {
+                throw new IOException(
+                        String.format(
+                                "'%s' opens %s instead of expected HttpURLConnection",
+                                home, raw.getClass().getName()
+                        )
+                );
+            }
             HttpURLConnection conn = null;
             try {
-                conn = this.createConnection(
-                        home, connect, read, method, headers, sslcontext
+                conn = this.createHttpUrlConnection(
+                        raw, connect, read, method, headers, sslcontext
                 );
                 if (method.equals(Request.POST) || method.equals(Request.PUT)
                     || method.equals(Request.PATCH)) {
@@ -127,19 +136,11 @@ public final class JdkRequest implements Request {
             }
         }
         // @checkstyle ParameterNumber (4 lines)
-        private HttpURLConnection createConnection(final String home,
-            final int connect, final int read, final String method,
-            final Collection<Map.Entry<String, String>> headers,
-            final SSLContext sslcontext) throws IOException {
-            final URLConnection raw = new URL(home).openConnection();
-            if (!(raw instanceof HttpURLConnection)) {
-                throw new IOException(
-                    String.format(
-                        "'%s' opens %s instead of expected HttpURLConnection",
-                        home, raw.getClass().getName()
-                    )
-                );
-            }
+        private HttpURLConnection createHttpUrlConnection(final URLConnection raw,
+                                                          final int connect, final int read, final String method,
+                                                          final Collection<Map.Entry<String, String>> headers,
+                                                          final SSLContext sslcontext) throws IOException {
+
             final HttpURLConnection conn = HttpURLConnection.class.cast(raw);
             conn.setConnectTimeout(connect);
             conn.setReadTimeout(read);

--- a/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -109,9 +110,10 @@ public final class AutoRedirectingWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         Response response = this.origin.send(
-            req, home, method, headers, content, connect, read
+            req, home, method, headers, content, connect, read, sslcontext
         );
         int attempt = 1;
         final URI uri = URI.create(home);
@@ -132,7 +134,7 @@ public final class AutoRedirectingWire implements Wire {
             }
             response = this.origin.send(
                 req, location.toString(),
-                method, headers, content, connect, read
+                method, headers, content, connect, read, sslcontext
             );
             try {
                 TimeUnit.SECONDS.sleep((long) attempt);

--- a/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
+++ b/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
@@ -42,6 +42,7 @@ import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.xml.bind.DatatypeConverter;
 import lombok.EqualsAndHashCode;
@@ -104,7 +105,8 @@ public final class BasicAuthWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         final Collection<Map.Entry<String, String>> hdrs =
             new LinkedList<Map.Entry<String, String>>();
         boolean absent = true;
@@ -134,7 +136,7 @@ public final class BasicAuthWire implements Wire {
             );
         }
         return this.origin.send(
-            req, home, method, hdrs, content, connect, read
+            req, home, method, hdrs, content, connect, read, sslcontext
         );
     }
 }

--- a/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -97,7 +98,8 @@ public final class CookieOptimizingWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         final Collection<Map.Entry<String, String>> hdrs =
             new LinkedList<Map.Entry<String, String>>();
         final ConcurrentMap<String, String> cookies =
@@ -138,7 +140,7 @@ public final class CookieOptimizingWire implements Wire {
             );
         }
         return this.origin.send(
-            req, home, method, hdrs, content, connect, read
+            req, home, method, hdrs, content, connect, read, sslcontext
         );
     }
 }

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -55,6 +55,7 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.FileUtils;
@@ -70,6 +71,7 @@ import org.apache.commons.io.FileUtils;
 @Immutable
 @ToString
 @EqualsAndHashCode
+@SuppressWarnings("PMD.ExcessiveImports")
 final class FcCache {
 
     /**
@@ -124,14 +126,17 @@ final class FcCache {
      * @param input Input body
      * @param connect Connect timeout
      * @param read Read timeout
+     * @param sslcontext SSL Context
      * @return Response
      * @throws IOException If fails
      * @checkstyle ParameterNumberCheck (10 lines)
      */
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public Response get(final String label, final Wire wire,
         final Request request, final String home, final String method,
         final Collection<Map.Entry<String, String>> headers,
-        final InputStream input, final int connect, final int read)
+        final InputStream input, final int connect, final int read,
+        final SSLContext sslcontext)
         throws IOException {
         final File file = this.file(label);
         final Response rsp;
@@ -141,7 +146,7 @@ final class FcCache {
             rsp = this.saved(
                 wire.send(
                     request, home, method,
-                    headers, input, connect, read
+                    headers, input, connect, read, sslcontext
                 ),
                 file
             );

--- a/src/main/java/com/jcabi/http/wire/FcWire.java
+++ b/src/main/java/com/jcabi/http/wire/FcWire.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -138,7 +139,8 @@ public final class FcWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         final URI uri = req.uri().get();
         final StringBuilder label = new StringBuilder(Tv.HUNDRED)
             .append(method).append(' ').append(uri.getPath());
@@ -152,12 +154,12 @@ public final class FcWire implements Wire {
         if (method.equals(Request.GET)) {
             rsp = this.cache.get(
                 label.toString(), this.origin, req,
-                home, method, headers, content, connect, read
+                home, method, headers, content, connect, read, sslcontext
             );
         } else {
             rsp = this.origin.send(
                 req, home, method, headers, content,
-                connect, read
+                connect, read, sslcontext
             );
         }
         return rsp;

--- a/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
+++ b/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -87,9 +88,10 @@ public final class OneMinuteWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         return this.origin.send(
-            req, home, method, headers, content, connect, read
+            req, home, method, headers, content, connect, read, sslcontext
         );
     }
 }

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -88,7 +89,8 @@ public final class RetryWire implements Wire {
         final String method,
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
-        final int connect, final int read) throws IOException {
+        final int connect, final int read,
+        final SSLContext sslcontext) throws IOException {
         int attempt = 0;
         while (true) {
             if (attempt > Tv.THREE) {
@@ -99,7 +101,7 @@ public final class RetryWire implements Wire {
             try {
                 final Response rsp = this.origin.send(
                     req, home, method, headers, content,
-                    connect, read
+                    connect, read, sslcontext
                 );
                 if (rsp.status() < HttpURLConnection.HTTP_INTERNAL_ERROR) {
                     return rsp;

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -109,15 +109,9 @@ public final class TrustedWire implements Wire {
         final InputStream content,
         final int connect, final int read,
         final SSLContext context) throws IOException {
-        final SSLContext resolvedContext;
-        if (context == null) {
-            resolvedContext = context();
-        } else {
-            resolvedContext = context;
-        }
         return this.origin.send(
                 req, home, method, headers, content,
-                connect, read, resolvedContext
+                connect, read, context()
         );
     }
 

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -41,9 +41,7 @@ import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Map;
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import lombok.EqualsAndHashCode;
@@ -109,22 +107,18 @@ public final class TrustedWire implements Wire {
         final String method,
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
-        final int connect, final int read) throws IOException {
-        synchronized (TrustedWire.class) {
-            final SSLSocketFactory def =
-                HttpsURLConnection.getDefaultSSLSocketFactory();
-            try {
-                HttpsURLConnection.setDefaultSSLSocketFactory(
-                    TrustedWire.context().getSocketFactory()
-                );
-                return this.origin.send(
-                    req, home, method, headers, content,
-                    connect, read
-                );
-            } finally {
-                HttpsURLConnection.setDefaultSSLSocketFactory(def);
-            }
+        final int connect, final int read,
+        final SSLContext context) throws IOException {
+        final SSLContext resolvedContext;
+        if (context == null) {
+            resolvedContext = context();
+        } else {
+            resolvedContext = context;
         }
+        return this.origin.send(
+                req, home, method, headers, content,
+                connect, read, resolvedContext
+        );
     }
 
     /**

--- a/src/main/java/com/jcabi/http/wire/UserAgentWire.java
+++ b/src/main/java/com/jcabi/http/wire/UserAgentWire.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.HttpHeaders;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -103,7 +104,8 @@ public final class UserAgentWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         final Collection<Map.Entry<String, String>> hdrs =
             new LinkedList<Map.Entry<String, String>>();
         boolean absent = true;
@@ -122,7 +124,7 @@ public final class UserAgentWire implements Wire {
             );
         }
         return this.origin.send(
-            req, home, method, hdrs, content, connect, read
+            req, home, method, hdrs, content, connect, read, sslcontext
         );
     }
 }

--- a/src/main/java/com/jcabi/http/wire/VerboseWire.java
+++ b/src/main/java/com/jcabi/http/wire/VerboseWire.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -88,7 +89,8 @@ public final class VerboseWire implements Wire {
         final Collection<Map.Entry<String, String>> headers,
         final InputStream content,
         final int connect,
-        final int read) throws IOException {
+        final int read,
+        final SSLContext sslcontext) throws IOException {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         final byte[] buffer = new byte[Tv.THOUSAND];
         for (int bytes = content.read(buffer); bytes != -1;
@@ -99,7 +101,7 @@ public final class VerboseWire implements Wire {
         final Response response = this.origin.send(
             req, home, method, headers,
             new ByteArrayInputStream(output.toByteArray()),
-                connect, read
+                connect, read, sslcontext
         );
         final StringBuilder text = new StringBuilder(0);
         for (final Map.Entry<String, String> header : headers) {

--- a/src/test/java/com/jcabi/http/MockWire.java
+++ b/src/test/java/com/jcabi/http/MockWire.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map.Entry;
+import javax.net.ssl.SSLContext;
 
 /**
  * Utility wire used for injecting a mock object into a {@link Request}
@@ -72,7 +73,8 @@ public class MockWire implements Wire {
     public final Response send(final Request req, final String home,
             final String method,
             final Collection<Entry<String, String>> headers,
-            final InputStream content, final int connect, final int read)
+            final InputStream content, final int connect, final int read,
+            final SSLContext sslcontext)
             throws IOException {
         return mockDelegate.send(
                 req,
@@ -81,7 +83,8 @@ public class MockWire implements Wire {
                 headers,
                 content,
                 connect,
-                read
+                read,
+                sslcontext
         );
     }
 

--- a/src/test/java/com/jcabi/http/RequestITCase.java
+++ b/src/test/java/com/jcabi/http/RequestITCase.java
@@ -81,7 +81,7 @@ public final class RequestITCase {
      */
     @Test
     public void sendsHttpRequestAndProcessesHttpResponse() throws Exception {
-        this.request(new URI("http://http.jcabi.com"))
+        this.request(new URI("https://http.jcabi.com"))
             .fetch().as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(XmlResponse.class)
@@ -94,7 +94,7 @@ public final class RequestITCase {
      */
     @Test
     public void processesNotOkHttpResponse() throws Exception {
-        this.request(new URI("http://http.jcabi.com/file-not-found.txt"))
+        this.request(new URI("https://http.jcabi.com/file-not-found.txt"))
             .fetch().as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
     }

--- a/src/test/java/com/jcabi/http/RequestSslContextITCase.java
+++ b/src/test/java/com/jcabi/http/RequestSslContextITCase.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2011-2017, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.http;
+
+import com.jcabi.http.request.ApacheRequest;
+import com.jcabi.http.request.JdkRequest;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Integration case for use of ssl context.
+ * @author Joris Lambrechts (lambrechts.joris@gmail.com)
+ * @version $Id$
+ */
+public class RequestSslContextITCase {
+
+    /**
+     * The https url to verify secure connections can be requested.
+     */
+    private static final String URL = "https://sha512.badssl.com/";
+    /**
+     * Custom error message to verify custom ssl context is used.
+     */
+    private static final String MESSAGE = "Trust no one";
+    /**
+     * Assertion error message if fetch should succeed.
+     */
+    private static final String FETCH_SHOULD_FAIL =
+            "fetch() should have thrown IOException.";
+
+    /**
+     * Test if {@link JdkRequest} uses the provided {@link SSLContext}.
+     */
+    @Test
+    public final void jdkRequest() {
+        try {
+            new JdkRequest(URL)
+                    .sslcontext(this.createContext())
+                    .fetch();
+            Assert.fail(FETCH_SHOULD_FAIL);
+        } catch (final IOException exception) {
+            final String expectedMessage =
+                    "Failed GET request to https://sha512.badssl.com/";
+            Assert.assertEquals(expectedMessage, exception.getMessage());
+            final Throwable rootCause = ExceptionUtils.getRootCause(exception);
+            Assert.assertThat(
+                    rootCause,
+                    CoreMatchers.<Throwable>instanceOf(
+                            CertificateException.class
+                    )
+            );
+            Assert.assertEquals(MESSAGE, rootCause.getMessage());
+        }
+    }
+
+    /**
+     * Test if {@link ApacheRequest} uses the provided {@link SSLContext}.
+     */
+    @Test
+    public final void apacheRequest() {
+        try {
+            new ApacheRequest(URL)
+                    .sslcontext(this.createContext())
+                    .fetch();
+            Assert.fail(FETCH_SHOULD_FAIL);
+        } catch (final IOException exception) {
+            final String expectedMessage =
+                    "java.security.cert.CertificateException: Trust no one";
+            Assert.assertEquals(expectedMessage, exception.getMessage());
+            final Throwable rootCause = ExceptionUtils.getRootCause(exception);
+            Assert.assertThat(
+                    rootCause,
+                    CoreMatchers.<Throwable>instanceOf(
+                            CertificateException.class
+                    )
+            );
+            Assert.assertEquals(MESSAGE, rootCause.getMessage());
+        }
+    }
+
+    /**
+     * Create a custom SSL Context that trusts no certificates.
+     * @return A new TLS {@link SSLContext}
+     */
+    @SneakyThrows
+    private SSLContext createContext() {
+        final SSLContext tls = SSLContext.getInstance("TLS");
+        tls.init(
+                null,
+                new TrustManager[] {new NoTrustManager()},
+                new SecureRandom()
+        );
+        return tls;
+    }
+
+    /**
+     * A trust manager that trusts nothing.
+     */
+    private static class NoTrustManager implements X509TrustManager {
+        @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+        @Override
+        public void checkClientTrusted(
+                final X509Certificate[] chain,
+                final String authtype
+        ) {
+        }
+        @Override
+        public void checkServerTrusted(
+                final X509Certificate[] chain,
+                final String authtype
+        ) throws CertificateException {
+            throw new CertificateException(MESSAGE);
+        }
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+
+    }
+
+}

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -48,6 +48,7 @@ import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
@@ -746,7 +747,8 @@ public final class RequestTest {
                             Mockito.<Map.Entry<String, String>>anyCollection(),
                             Mockito.any(InputStream.class),
                             Mockito.anyInt(),
-                            Mockito.anyInt()
+                            Mockito.anyInt(),
+                            Mockito.any(SSLContext.class)
                     )
             ).thenReturn(mockResponse);
             execution.run();
@@ -757,7 +759,8 @@ public final class RequestTest {
                     Mockito.<Map.Entry<String, String>>anyCollection(),
                     Mockito.any(InputStream.class),
                     connectCaptor.capture(),
-                    readCaptor.capture()
+                    readCaptor.capture(),
+                    Mockito.any(SSLContext.class)
             );
             MatcherAssert.assertThat(
                     connectCaptor.getValue().intValue(),

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -34,12 +34,6 @@ import com.google.common.base.Supplier;
 import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.request.BaseRequest;
 import com.jcabi.http.request.JdkRequest;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -47,6 +41,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * Test case for loss of timeout parameters.
@@ -336,7 +338,8 @@ public final class RequestTimeoutLossTest {
                         hdrs.get(),
                         org.mockito.Matchers.any(InputStream.class),
                         org.mockito.Matchers.anyInt(),
-                        org.mockito.Matchers.anyInt()
+                        org.mockito.Matchers.anyInt(),
+                        org.mockito.Matchers.any(SSLContext.class)
                 )
         ).thenReturn(response);
         new BaseRequest(original, url).through(wire).fetch();
@@ -347,7 +350,8 @@ public final class RequestTimeoutLossTest {
                 hdrs.get(),
                 org.mockito.Matchers.any(InputStream.class),
                 org.mockito.Matchers.anyInt(),
-                org.mockito.Matchers.anyInt()
+                org.mockito.Matchers.anyInt(),
+                org.mockito.Matchers.any(SSLContext.class)
         );
         Mockito.verify(wire).send(
                 org.mockito.Matchers.any(Request.class),
@@ -356,7 +360,8 @@ public final class RequestTimeoutLossTest {
                 hdrs.get(),
                 org.mockito.Matchers.any(InputStream.class),
                 org.mockito.Matchers.anyInt(),
-                org.mockito.Matchers.anyInt()
+                org.mockito.Matchers.anyInt(),
+                org.mockito.Matchers.any(SSLContext.class)
         );
     }
 
@@ -386,7 +391,8 @@ public final class RequestTimeoutLossTest {
                             Mockito.<Map.Entry<String, String>>anyCollection(),
                             Mockito.any(InputStream.class),
                             Mockito.anyInt(),
-                            Mockito.anyInt()
+                            Mockito.anyInt(),
+                            org.mockito.Matchers.any(SSLContext.class)
                     )
             ).thenReturn(mockResponse);
             execution.run();
@@ -397,7 +403,8 @@ public final class RequestTimeoutLossTest {
                     Mockito.<Map.Entry<String, String>>anyCollection(),
                     Mockito.any(InputStream.class),
                     connectCaptor.capture(),
-                    readCaptor.capture()
+                    readCaptor.capture(),
+                    org.mockito.Matchers.any(SSLContext.class)
             );
             MatcherAssert.assertThat(
                     connectCaptor.getValue().intValue(),

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -34,6 +34,13 @@ import com.google.common.base.Supplier;
 import com.jcabi.http.request.ApacheRequest;
 import com.jcabi.http.request.BaseRequest;
 import com.jcabi.http.request.JdkRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -41,14 +48,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
-import javax.net.ssl.SSLContext;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
 
 /**
  * Test case for loss of timeout parameters.

--- a/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
@@ -50,13 +50,12 @@ public final class TrustedWireITCase {
      */
     @Test
     public void ignoresPkixErrors() throws Exception {
-        new JdkRequest("https://api.travis-ci.org/test")
+        new JdkRequest("https://expired.badssl.com/")
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
             .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
             .through(TrustedWire.class)
             .fetch()
             .as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
+            .assertStatus(HttpURLConnection.HTTP_OK);
     }
-
 }


### PR DESCRIPTION
I opted to add another parameter to the `Wire.send` method although the list of parameters is too high. I ran the same test from the issue with the `TrustedWire` and got the same result as previous without it so that's good enough for me.

Any feedback is welcome.

https://github.com/jcabi/jcabi-http/issues/178