### PR TITLE
For #171: Bump parent to jcabi 1.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>2.2.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,15 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!--
+      @todo #171:30m Migrate all simple tests to Junit 5. For the sake of
+       smaller PRs, migration can be done in steps
+       1) All tests classes without @Rule, and @Test(expected = ...)
+       2) All parameterized tests classes
+       3) The rest, (i.e dependent on @Rule's and so on)
+       After completing one of the steps, create a new puzzle for the next.
+       After all tests are run by Junit 5 remove this dependency.
+      -->
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <version>${junit-platform.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,35 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!--
+      @todo #171:30m Transitive dependencies for hamcrest 1.3 and junit 4
+       comes from this dependency.
+       1) Upgrade jcabi-matchers to the same version of parent as jcabi-http.
+       2) Replace hamcrest 1.3 with hamcrest 2.2 (?) from parent
+       3) Replace junit 5 with junit 5
+      -->
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <scope>provided</scope>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -120,18 +145,6 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <version>0.20</version>
       <scope>provided</scope>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <optional>true</optional>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-platform.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi</artifactId>
-    <version>1.24</version>
+    <version>1.25.1</version>
   </parent>
   <artifactId>jcabi-http</artifactId>
   <version>2.0-SNAPSHOT</version>
@@ -123,15 +123,15 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <optional>true</optional>
-      <scope>provided</scope>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-platform.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -306,20 +306,8 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>cobertura-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>site</phase>
-                <goals>
-                  <goal>cobertura</goal>
-                </goals>
-                <configuration>
-                  <format>xml</format>
-                  <maxmem>256m</maxmem>
-                </configuration>
-              </execution>
-            </executions>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
           </plugin>
           <plugin>
             <groupId>org.eluder.coveralls</groupId>

--- a/src/main/java/com/jcabi/http/ImmutableHeader.java
+++ b/src/main/java/com/jcabi/http/ImmutableHeader.java
@@ -86,6 +86,7 @@ public final class ImmutableHeader implements Map.Entry<String, String> {
      * @param key The key to normalize
      * @return Normalized key
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static String normalize(final String key) {
         final char[] chars = key.toCharArray();
         chars[0] = ImmutableHeader.upper(chars[0]);

--- a/src/main/java/com/jcabi/http/ImmutableHeader.java
+++ b/src/main/java/com/jcabi/http/ImmutableHeader.java
@@ -37,7 +37,6 @@ import lombok.ToString;
 /**
  * Immutable HTTP header.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/ImmutableHeader.java
+++ b/src/main/java/com/jcabi/http/ImmutableHeader.java
@@ -37,7 +37,6 @@ import lombok.ToString;
 /**
  * Immutable HTTP header.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/ImmutableHeader.java
+++ b/src/main/java/com/jcabi/http/ImmutableHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -71,7 +71,6 @@ import java.io.InputStream;
  * possible HTTP methods (JdkRequest doesn't support {@code PATCH},
  * for example).
  *
- * @version $Id$
  * @since 0.8
  * @see com.jcabi.http.request.JdkRequest
  * @see com.jcabi.http.request.ApacheRequest

--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -71,7 +71,6 @@ import java.io.InputStream;
  * possible HTTP methods (JdkRequest doesn't support {@code PATCH},
  * for example).
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * @see com.jcabi.http.request.JdkRequest

--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/RequestBody.java
+++ b/src/main/java/com/jcabi/http/RequestBody.java
@@ -30,7 +30,7 @@
 package com.jcabi.http;
 
 import com.jcabi.aspects.Immutable;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import javax.json.JsonStructure;
 
@@ -110,18 +110,18 @@ public interface RequestBody {
 
     /**
      * Printer of byte array.
+     *
+     * @since 1.0
      */
     @Immutable
     final class Printable {
-        /**
-         * The Charset to use.
-         */
-        private static final Charset CHARSET = Charset.forName("UTF-8");
+
         /**
          * Byte array.
          */
         @Immutable.Array
         private final transient byte[] array;
+
         /**
          * Ctor.
          * @param bytes Bytes to encapsulate
@@ -129,11 +129,12 @@ public interface RequestBody {
         public Printable(final byte[] bytes) {
             this.array = bytes;
         }
+
         @Override
         public String toString() {
             final StringBuilder text = new StringBuilder(0);
             final char[] chrs = new String(
-                this.array, RequestBody.Printable.CHARSET
+                this.array, StandardCharsets.UTF_8
             ).toCharArray();
             if (chrs.length > 0) {
                 for (final char chr : chrs) {

--- a/src/main/java/com/jcabi/http/RequestBody.java
+++ b/src/main/java/com/jcabi/http/RequestBody.java
@@ -53,7 +53,6 @@ import javax.json.JsonStructure;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  */

--- a/src/main/java/com/jcabi/http/RequestBody.java
+++ b/src/main/java/com/jcabi/http/RequestBody.java
@@ -53,7 +53,6 @@ import javax.json.JsonStructure;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/RequestBody.java
+++ b/src/main/java/com/jcabi/http/RequestBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/RequestURI.java
+++ b/src/main/java/com/jcabi/http/RequestURI.java
@@ -51,7 +51,6 @@ import java.util.Map;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  * @checkstyle AbbreviationAsWordInNameCheck (100 lines)
  */

--- a/src/main/java/com/jcabi/http/RequestURI.java
+++ b/src/main/java/com/jcabi/http/RequestURI.java
@@ -51,7 +51,6 @@ import java.util.Map;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * @checkstyle AbbreviationAsWordInNameCheck (100 lines)

--- a/src/main/java/com/jcabi/http/RequestURI.java
+++ b/src/main/java/com/jcabi/http/RequestURI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/Response.java
+++ b/src/main/java/com/jcabi/http/Response.java
@@ -44,7 +44,6 @@ import java.util.Map;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * @see com.jcabi.http.request.JdkRequest

--- a/src/main/java/com/jcabi/http/Response.java
+++ b/src/main/java/com/jcabi/http/Response.java
@@ -44,7 +44,6 @@ import java.util.Map;
  *
  * <p>Instances of this interface are immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  * @see com.jcabi.http.request.JdkRequest
  */

--- a/src/main/java/com/jcabi/http/Response.java
+++ b/src/main/java/com/jcabi/http/Response.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/Wire.java
+++ b/src/main/java/com/jcabi/http/Wire.java
@@ -52,7 +52,6 @@ import java.util.Map;
  * <p>Every {@code Wire} decorator passed to {@code through()} method
  * wraps a previously existing one.
  *
- * @version $Id$
  * @since 0.9
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/Wire.java
+++ b/src/main/java/com/jcabi/http/Wire.java
@@ -52,7 +52,6 @@ import java.util.Map;
  * <p>Every {@code Wire} decorator passed to {@code through()} method
  * wraps a previously existing one.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.9
  */

--- a/src/main/java/com/jcabi/http/Wire.java
+++ b/src/main/java/com/jcabi/http/Wire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
+++ b/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Mock HTTP query/request.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
+++ b/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
@@ -164,6 +164,7 @@ final class GrizzlyQuery implements MkQuery {
         }
         return list;
     }
+
     /**
      * Read req.
      * @param req Grizzly req

--- a/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
+++ b/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
+++ b/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Mock HTTP query/request.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
+++ b/src/main/java/com/jcabi/http/mock/GrizzlyQuery.java
@@ -83,6 +83,7 @@ final class GrizzlyQuery implements MkQuery {
      * @param request Grizzly request
      * @throws IOException If fails
      */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     GrizzlyQuery(final GrizzlyRequest request) throws IOException {
         request.setCharacterEncoding(StandardCharsets.UTF_8.toString());
         this.home = GrizzlyQuery.uri(request);

--- a/src/main/java/com/jcabi/http/mock/MkAnswer.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswer.java
@@ -79,28 +79,34 @@ public interface MkAnswer {
 
     /**
      * Simple implementation.
+     *
+     * @since 1.0
      */
     @Immutable
-    @EqualsAndHashCode(of = { "code", "hdrs", "content" })
+    @EqualsAndHashCode(of = {"code", "hdrs", "content"})
     @Loggable(Loggable.DEBUG)
     final class Simple implements MkAnswer {
         /**
          * The Charset to use.
          */
         private static final Charset CHARSET = Charset.forName("UTF-8");
+
         /**
          * Encapsulated response.
          */
         private final transient int code;
+
         /**
          * Headers.
          */
         private final transient Array<Map.Entry<String, String>> hdrs;
+
         /**
          * Content received.
          */
         @Immutable.Array
         private final transient byte[] content;
+
         /**
          * Public ctor.
          * @param body Body of HTTP response
@@ -108,6 +114,7 @@ public interface MkAnswer {
         public Simple(final String body) {
             this(HttpURLConnection.HTTP_OK, body);
         }
+
         /**
          * Public ctor (with empty HTTP body).
          * @param status HTTP status
@@ -116,6 +123,7 @@ public interface MkAnswer {
         public Simple(final int status) {
             this(status, "");
         }
+
         /**
          * Public ctor.
          * @param status HTTP status
@@ -127,6 +135,7 @@ public interface MkAnswer {
                 body.getBytes(MkAnswer.Simple.CHARSET)
             );
         }
+
         /**
          * Public ctor.
          * @param status HTTP status
@@ -137,13 +146,15 @@ public interface MkAnswer {
             final Iterable<Map.Entry<String, String>> headers,
             final byte[] body) {
             this.code = status;
-            this.hdrs = new Array<Map.Entry<String, String>>(headers);
+            this.hdrs = new Array<>(headers);
             this.content = body.clone();
         }
+
         @Override
         public int status() {
             return this.code;
         }
+
         @Override
         @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
         public Map<String, List<String>> headers() {
@@ -155,14 +166,17 @@ public interface MkAnswer {
             }
             return map;
         }
+
         @Override
         public String body() {
             return new String(this.content, MkAnswer.Simple.CHARSET);
         }
+
         @Override
         public byte[] bodyBytes() {
             return this.content.clone();
         }
+
         @Override
         public String toString() {
             final StringBuilder text = new StringBuilder(0)
@@ -180,6 +194,7 @@ public interface MkAnswer {
                 .append(new RequestBody.Printable(this.content))
                 .toString();
         }
+
         /**
          * Make a copy of this answer, with an extra header.
          * @param name Name of the header
@@ -194,6 +209,7 @@ public interface MkAnswer {
                 this.content
             );
         }
+
         /**
          * Make a copy of this answer, with another status code.
          * @param status Status code
@@ -206,6 +222,7 @@ public interface MkAnswer {
                 this.content
             );
         }
+
         /**
          * Make a copy of this answer, with another body.
          * @param body Body
@@ -218,6 +235,7 @@ public interface MkAnswer {
                 body.getBytes(MkAnswer.Simple.CHARSET)
             );
         }
+
         /**
          * Make a copy of this answer, with another body.
          * @param body Body

--- a/src/main/java/com/jcabi/http/mock/MkAnswer.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswer.java
@@ -47,7 +47,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Mock response.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/mock/MkAnswer.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswer.java
@@ -47,7 +47,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Mock response.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/mock/MkAnswer.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#bodyBytes()} result.
- * @version $Id$
  * @since 0.17
  */
 @ToString

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
@@ -66,6 +66,5 @@ final class MkAnswerBodyBytesMatcher extends TypeSafeMatcher<MkAnswer> {
     @Override
     public boolean matchesSafely(final MkAnswer item) {
         return this.matcher.matches(item.bodyBytes());
-    };
-
+    }
 }

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyBytesMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#bodyBytes()} result.
- * @author Peter Storch (peter.storch@gmail.com)
  * @version $Id$
  * @since 0.17
  */

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#body()} result.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#body()} result.
- * @version $Id$
  * @since 1.5
  */
 @ToString

--- a/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerBodyMatcher.java
@@ -66,6 +66,5 @@ final class MkAnswerBodyMatcher extends TypeSafeMatcher<MkAnswer> {
     @Override
     public boolean matchesSafely(final MkAnswer item) {
         return this.matcher.matches(item.body());
-    };
-
+    }
 }

--- a/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#headers()} contents.
- * @version $Id$
  * @since 1.5
  */
 @ToString

--- a/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkAnswer#headers()} contents.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
@@ -40,7 +40,7 @@ import org.hamcrest.TypeSafeMatcher;
  * @since 1.5
  */
 @ToString
-@EqualsAndHashCode(callSuper = false, of = { "header", "matcher" })
+@EqualsAndHashCode(callSuper = false, of = {"header", "matcher"})
 final class MkAnswerHeaderMatcher extends TypeSafeMatcher<MkAnswer> {
     /**
      * The header to match.
@@ -77,5 +77,5 @@ final class MkAnswerHeaderMatcher extends TypeSafeMatcher<MkAnswer> {
     public boolean matchesSafely(final MkAnswer item) {
         return item.headers().containsKey(this.header)
             && this.matcher.matches(item.headers().get(this.header));
-    };
+    }
 }

--- a/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerHeaderMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
@@ -33,7 +33,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Convenient set of matchers for {@link MkAnswer}.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
@@ -37,6 +37,7 @@ import org.hamcrest.Matcher;
  * @version $Id$
  * @since 1.5
  */
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public final class MkAnswerMatchers {
     /**
      * Private ctor.

--- a/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkAnswerMatchers.java
@@ -33,7 +33,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Convenient set of matchers for {@link MkAnswer}.
- * @version $Id$
  * @since 1.5
  */
 @SuppressWarnings("PMD.ProhibitPublicStaticMethods")

--- a/src/main/java/com/jcabi/http/mock/MkContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkContainer.java
@@ -62,7 +62,6 @@ import org.hamcrest.Matcher;
  * <p>Since version 0.11 container implements {@link Closeable} and can be
  * used in try-with-resource block.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see <a href="http://www.rexsl.com/rexsl-test/example-mock-servlet.html">Examples</a>

--- a/src/main/java/com/jcabi/http/mock/MkContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkContainer.java
@@ -62,7 +62,6 @@ import org.hamcrest.Matcher;
  * <p>Since version 0.11 container implements {@link Closeable} and can be
  * used in try-with-resource block.
  *
- * @version $Id$
  * @since 0.10
  * @see <a href="http://www.rexsl.com/rexsl-test/example-mock-servlet.html">Examples</a>
  */

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -52,7 +52,6 @@ import org.hamcrest.Matcher;
 /**
  * Mocker of Java Servlet container.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (300 lines)

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -382,6 +382,9 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
 
         @Override
         public MkQuery next() {
+            if (this.results.isEmpty()) {
+                throw new NoSuchElementException();
+            }
             return this.results.remove();
         }
 

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -382,7 +382,7 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
 
         @Override
         public MkQuery next() {
-            return this.results.poll();
+            return this.results.remove();
         }
 
         @Override

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -52,7 +52,6 @@ import org.hamcrest.Matcher;
 /**
  * Mocker of Java Servlet container.
  *
- * @version $Id$
  * @since 0.10
  * @checkstyle ClassDataAbstractionCouplingCheck (300 lines)
  */

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -231,6 +231,8 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
 
     /**
      * Answer with condition.
+     *
+     * @since 1.5
      */
     @EqualsAndHashCode(of = {"answr", "condition"})
     private static final class Conditional {
@@ -238,10 +240,12 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
          * The MkAnswer.
          */
         private final transient MkAnswer answr;
+
         /**
          * Condition for this answer.
          */
         private final transient Matcher<MkQuery> condition;
+
         /**
          * The number of times the answer is expected to appear.
          */
@@ -303,6 +307,8 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
 
     /**
      * Query with answer.
+     *
+     * @since 1.5
      */
     @EqualsAndHashCode(of = {"answr", "que"})
     private static final class QueryWithAnswer {
@@ -310,6 +316,7 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
          * The answer.
          */
         private final transient MkAnswer answr;
+
         /**
          * The query.
          */

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -261,14 +261,9 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
             final int times) {
             this.answr = ans;
             this.condition = matcher;
-            if (times < 1) {
-                throw new IllegalArgumentException(
-                    "Answer must be returned at least once."
-                );
-            } else {
-                this.count = new AtomicInteger(times);
-            }
+            this.count = Conditional.positiveAtomic(times);
         }
+
         /**
          * Get the answer.
          * @return The answer
@@ -291,6 +286,21 @@ final class MkGrizzlyAdapter extends GrizzlyAdapter {
         public int decrement() {
             return this.count.decrementAndGet();
         }
+
+        /**
+         * Check if positive and convert to atomic.
+         * @param num Number
+         * @return Positive atomic integer
+         */
+        private static AtomicInteger positiveAtomic(final int num) {
+            if (num < 1) {
+                throw new IllegalArgumentException(
+                    "Answer must be returned at least once."
+                );
+            }
+            return new AtomicInteger(num);
+        }
+
     }
 
     /**

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
@@ -158,7 +158,7 @@ public final class MkGrizzlyContainer implements MkContainer {
     @RetryOnFailure
     private static int reserve() throws IOException {
         final int reserved;
-        try (final ServerSocket socket = new ServerSocket(0)) {
+        try (ServerSocket socket = new ServerSocket(0)) {
             reserved = socket.getLocalPort();
         }
         return reserved;

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
@@ -44,7 +44,6 @@ import org.hamcrest.core.IsAnything;
 /**
  * Implementation of {@link MkContainer} based on Grizzly Server.
  *
- * @version $Id$
  * @since 0.10
  * @see MkContainer
  */

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
@@ -44,7 +44,6 @@ import org.hamcrest.core.IsAnything;
 /**
  * Implementation of {@link MkContainer} based on Grizzly Server.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see MkContainer

--- a/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
+++ b/src/main/java/com/jcabi/http/mock/MkGrizzlyContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkQuery.java
+++ b/src/main/java/com/jcabi/http/mock/MkQuery.java
@@ -37,7 +37,6 @@ import java.util.Map;
 /**
  * Mock HTTP query/request.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/mock/MkQuery.java
+++ b/src/main/java/com/jcabi/http/mock/MkQuery.java
@@ -37,7 +37,6 @@ import java.util.Map;
 /**
  * Mock HTTP query/request.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/mock/MkQuery.java
+++ b/src/main/java/com/jcabi/http/mock/MkQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkQuery#body()} result.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkQuery#body()} result.
- * @version $Id$
  * @since 1.5
  */
 @ToString

--- a/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
@@ -67,6 +67,6 @@ final class MkQueryBodyMatcher extends TypeSafeMatcher<MkQuery> {
     @Override
     public boolean matchesSafely(final MkQuery item) {
         return this.matcher.matches(item.body());
-    };
+    }
 
 }

--- a/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryBodyMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
@@ -40,7 +40,7 @@ import org.hamcrest.TypeSafeMatcher;
  * @since 1.5
  */
 @ToString
-@EqualsAndHashCode(callSuper = false, of = { "header", "matcher" })
+@EqualsAndHashCode(callSuper = false, of = {"header", "matcher"})
 final class MkQueryHeaderMatcher extends TypeSafeMatcher<MkQuery> {
 
     /**
@@ -78,6 +78,6 @@ final class MkQueryHeaderMatcher extends TypeSafeMatcher<MkQuery> {
     public boolean matchesSafely(final MkQuery item) {
         return item.headers().containsKey(this.header)
             && this.matcher.matches(item.headers().get(this.header));
-    };
+    }
 
 }

--- a/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkQuery#headers()} contents.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
@@ -37,7 +37,6 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for checking {@link MkQuery#headers()} contents.
- * @version $Id$
  * @since 1.5
  */
 @ToString

--- a/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryHeaderMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -33,7 +33,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Convenient set of matchers for {@link MkQuery}.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -37,6 +37,7 @@ import org.hamcrest.Matcher;
  * @version $Id$
  * @since 1.5
  */
+@SuppressWarnings("PMD.ProhibitPublicStaticMethods")
 public final class MkQueryMatchers {
 
     /**

--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -33,7 +33,6 @@ import org.hamcrest.Matcher;
 
 /**
  * Convenient set of matchers for {@link MkQuery}.
- * @version $Id$
  * @since 1.5
  */
 @SuppressWarnings("PMD.ProhibitPublicStaticMethods")

--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/mock/package-info.java
+++ b/src/main/java/com/jcabi/http/mock/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Mock of Servlet Container.
  *
- * @version $Id$
  * @since 0.10
  * @see <a href="http://www.rexsl.com/rexsl-test/example-mock-servlet.html">Examples</a>
  */

--- a/src/main/java/com/jcabi/http/mock/package-info.java
+++ b/src/main/java/com/jcabi/http/mock/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Mock of Servlet Container.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see <a href="http://www.rexsl.com/rexsl-test/example-mock-servlet.html">Examples</a>

--- a/src/main/java/com/jcabi/http/mock/package-info.java
+++ b/src/main/java/com/jcabi/http/mock/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/package-info.java
+++ b/src/main/java/com/jcabi/http/package-info.java
@@ -39,7 +39,6 @@
  *   &lt;artifactId&gt;rexsl-test&lt;/artifactId&gt;
  * &lt;/dependency&gt;</pre>
  *
- * @version $Id$
  * @see <a href="http://www.rexsl.com/rexsl-test">project site</a>
  */
 package com.jcabi.http;

--- a/src/main/java/com/jcabi/http/package-info.java
+++ b/src/main/java/com/jcabi/http/package-info.java
@@ -39,7 +39,6 @@
  *   &lt;artifactId&gt;rexsl-test&lt;/artifactId&gt;
  * &lt;/dependency&gt;</pre>
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @see <a href="http://www.rexsl.com/rexsl-test">project site</a>
  */

--- a/src/main/java/com/jcabi/http/package-info.java
+++ b/src/main/java/com/jcabi/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -63,7 +63,6 @@ import org.apache.http.util.EntityUtils;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -105,6 +105,7 @@ public final class ApacheRequest implements Request {
                 response.close();
             }
         }
+
         /**
          * Create request.
          * @param home Home URI
@@ -148,6 +149,7 @@ public final class ApacheRequest implements Request {
             }
             return req;
         }
+
         /**
          * Fetch body from http entity.
          * @param entity HTTP entity
@@ -163,6 +165,7 @@ public final class ApacheRequest implements Request {
             }
             return body;
         }
+
         /**
          * Make a list of all hdrs.
          * @param list Apache HTTP hdrs

--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -63,7 +63,6 @@ import org.apache.http.util.EntityUtils;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)
  */

--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -361,18 +361,20 @@ public final class BaseRequest implements Request {
             this.read
         );
         final URI uri = URI.create(this.home);
-        Logger.info(
-            this,
-            "#fetch(%s %s%s %s): [%d %s] in %[ms]s",
-            this.mtd,
-            uri.getHost(),
-            // @checkstyle AvoidInlineConditionalsCheck (1 line)
-            uri.getPort() > 0 ? String.format(":%d", uri.getPort()) : "",
-            uri.getPath(),
-            response.status(),
-            response.reason(),
-            System.currentTimeMillis() - start
-        );
+        if (Logger.isInfoEnabled(this)) {
+            Logger.info(
+                this,
+                "#fetch(%s %s%s %s): [%d %s] in %[ms]s",
+                this.mtd,
+                uri.getHost(),
+                // @checkstyle AvoidInlineConditionalsCheck (1 line)
+                uri.getPort() > 0 ? String.format(":%d", uri.getPort()) : "",
+                uri.getPath(),
+                response.status(),
+                response.reason(),
+                System.currentTimeMillis() - start
+            );
+        }
         return response;
     }
 

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -63,7 +63,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Base implementation of {@link Request}.
  *
- * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @see Request

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -182,12 +182,8 @@ public final class BaseRequest implements Request {
         final String method, final byte[] body,
         final int cnct, final int rdd) {
         this.wire = wre;
-        URI addr = URI.create(uri);
-        if (addr.getPath() != null && addr.getPath().isEmpty()) {
-            addr = UriBuilder.fromUri(addr).path("/").build();
-        }
-        this.home = addr.toString();
-        this.hdrs = new Array<Map.Entry<String, String>>(headers);
+        this.home = BaseRequest.createUri(uri).toString();
+        this.hdrs = new Array<>(headers);
         this.mtd = method;
         this.content = body.clone();
         this.connect = cnct;
@@ -753,5 +749,18 @@ public final class BaseRequest implements Request {
         }
 
     }
+    /**
+     * Create uri from String.
+     * @param uri String
+     * @return URI
+     */
+    private static URI createUri(final String uri) {
+        URI addr = URI.create(uri);
+        if (addr.getPath() != null && addr.getPath().isEmpty()) {
+            addr = UriBuilder.fromUri(addr).path("/").build();
+        }
+        return addr;
+    }
+
 
 }

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -63,7 +63,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Base implementation of {@link Request}.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -379,6 +379,19 @@ public final class BaseRequest implements Request {
     }
 
     /**
+     * Create uri from String.
+     * @param uri String
+     * @return URI
+     */
+    private static URI createUri(final String uri) {
+        URI addr = URI.create(uri);
+        if (addr.getPath() != null && addr.getPath().isEmpty()) {
+            addr = UriBuilder.fromUri(addr).path("/").build();
+        }
+        return addr;
+    }
+
+    /**
      * Base URI.
      */
     @Immutable
@@ -749,18 +762,5 @@ public final class BaseRequest implements Request {
         }
 
     }
-    /**
-     * Create uri from String.
-     * @param uri String
-     * @return URI
-     */
-    private static URI createUri(final String uri) {
-        URI addr = URI.create(uri);
-        if (addr.getPath() != null && addr.getPath().isEmpty()) {
-            addr = UriBuilder.fromUri(addr).path("/").build();
-        }
-        return addr;
-    }
-
 
 }

--- a/src/main/java/com/jcabi/http/request/BaseRequest.java
+++ b/src/main/java/com/jcabi/http/request/BaseRequest.java
@@ -391,6 +391,8 @@ public final class BaseRequest implements Request {
 
     /**
      * Base URI.
+     *
+     * @since 1.0
      */
     @Immutable
     @EqualsAndHashCode(of = "address")
@@ -502,6 +504,8 @@ public final class BaseRequest implements Request {
 
     /**
      * Body of a request with a form that has attachments.
+     *
+     * @since 1.17
      */
     private static final class MultipartFormBody implements RequestBody {
         /**
@@ -641,6 +645,8 @@ public final class BaseRequest implements Request {
     /**
      * Body of a request with a simple form.
      * (enctype application/x-www-form-urlencoded)
+     *
+     * @since 1.17
      */
     @Immutable
     @EqualsAndHashCode(of = "text")

--- a/src/main/java/com/jcabi/http/request/Boundary.java
+++ b/src/main/java/com/jcabi/http/request/Boundary.java
@@ -37,7 +37,6 @@ import java.util.Random;
  * Boundary for content-type multipart/form-data.
  * This is a copy of boundary created by Apache HttpComponents HttpClient 4.5.
  *
- * @version $Id$
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/request/Boundary.java
+++ b/src/main/java/com/jcabi/http/request/Boundary.java
@@ -80,7 +80,9 @@ public final class Boundary {
         final int count = this.rand.nextInt(11) + 30;
         for (int index = 0; index < count; ++index) {
             buffer.append(
-                MULTIPART_CHARS[this.rand.nextInt(MULTIPART_CHARS.length)]
+                Boundary.MULTIPART_CHARS[
+                    this.rand.nextInt(MULTIPART_CHARS.length)
+                    ]
             );
         }
         return buffer.toString();

--- a/src/main/java/com/jcabi/http/request/Boundary.java
+++ b/src/main/java/com/jcabi/http/request/Boundary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/Boundary.java
+++ b/src/main/java/com/jcabi/http/request/Boundary.java
@@ -37,7 +37,6 @@ import java.util.Random;
  * Boundary for content-type multipart/form-data.
  * This is a copy of boundary created by Apache HttpComponents HttpClient 4.5.
  *
- * @author Piotr Kotlicki (piotr.kotlicki@gmail.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/main/java/com/jcabi/http/request/DefaultResponse.java
+++ b/src/main/java/com/jcabi/http/request/DefaultResponse.java
@@ -48,7 +48,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Default implementation of {@link com.jcabi.http.Response}.
  *
- * @version $Id$
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/request/DefaultResponse.java
+++ b/src/main/java/com/jcabi/http/request/DefaultResponse.java
@@ -37,7 +37,7 @@ import com.jcabi.http.Response;
 import com.jcabi.immutable.Array;
 import com.jcabi.log.Logger;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -54,11 +54,6 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(of = { "req", "code", "phrase", "hdrs", "content" })
 @Loggable(Loggable.DEBUG)
 public final class DefaultResponse implements Response {
-
-    /**
-     * The Charset to use.
-     */
-    private static final Charset CHARSET = Charset.forName("UTF-8");
 
     /**
      * UTF-8 error marker.
@@ -139,7 +134,7 @@ public final class DefaultResponse implements Response {
 
     @Override
     public String body() {
-        final String body = new String(this.content, DefaultResponse.CHARSET);
+        final String body = new String(this.content, StandardCharsets.UTF_8);
         if (body.contains(DefaultResponse.ERR)) {
             throw new IllegalStateException(
                 Logger.format(
@@ -157,6 +152,7 @@ public final class DefaultResponse implements Response {
     public byte[] binary() {
         return this.content.clone();
     }
+
     // @checkstyle MethodName (4 lines)
     @Override
     @SuppressWarnings("PMD.ShortMethodName")

--- a/src/main/java/com/jcabi/http/request/DefaultResponse.java
+++ b/src/main/java/com/jcabi/http/request/DefaultResponse.java
@@ -48,7 +48,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Default implementation of {@link com.jcabi.http.Response}.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/main/java/com/jcabi/http/request/DefaultResponse.java
+++ b/src/main/java/com/jcabi/http/request/DefaultResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -53,7 +53,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.9
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)
  */

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/FakeRequest.java
+++ b/src/main/java/com/jcabi/http/request/FakeRequest.java
@@ -53,7 +53,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.9
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  * // @checkstyle ClassDataAbstractionCoupling (500 lines)
  */

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -132,6 +132,7 @@ public final class JdkRequest implements Request {
                 conn.disconnect();
             }
         }
+
         /**
          * Fully write the input stream contents to the output stream.
          * @param content The content to write
@@ -147,6 +148,7 @@ public final class JdkRequest implements Request {
                 output.write(buffer, 0, bytes);
             }
         }
+
         /**
          * Get headers from response.
          * @param fields ImmutableHeader fields
@@ -167,6 +169,7 @@ public final class JdkRequest implements Request {
             }
             return new Array<>(headers);
         }
+
         /**
          * Get response body of connection.
          * @param conn Connection

--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
+++ b/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 /**
  * Byte builder for multipart body.
  *
- * @version $Id$
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
+++ b/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 /**
  * Byte builder for multipart body.
  *
- * @author Piotr Kotlicki (piotr.kotlicki@gmail.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
+++ b/src/main/java/com/jcabi/http/request/MultipartBodyBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/request/package-info.java
+++ b/src/main/java/com/jcabi/http/request/package-info.java
@@ -39,7 +39,6 @@
  * {@link JdkRequest} doesn't support {@code PATCH} HTTP method due to
  * a bug in HttpURLConnection.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.request;

--- a/src/main/java/com/jcabi/http/request/package-info.java
+++ b/src/main/java/com/jcabi/http/request/package-info.java
@@ -39,7 +39,6 @@
  * {@link JdkRequest} doesn't support {@code PATCH} HTTP method due to
  * a bug in HttpURLConnection.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/request/package-info.java
+++ b/src/main/java/com/jcabi/http/request/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/AbstractResponse.java
+++ b/src/main/java/com/jcabi/http/response/AbstractResponse.java
@@ -39,7 +39,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Abstract response.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  */

--- a/src/main/java/com/jcabi/http/response/AbstractResponse.java
+++ b/src/main/java/com/jcabi/http/response/AbstractResponse.java
@@ -39,7 +39,6 @@ import lombok.EqualsAndHashCode;
 /**
  * Abstract response.
  *
- * @version $Id$
  * @since 0.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/response/AbstractResponse.java
+++ b/src/main/java/com/jcabi/http/response/AbstractResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/JacksonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JacksonResponse.java
@@ -43,7 +43,6 @@ import lombok.EqualsAndHashCode;
 /**
  * A JSON response provided by the Jackson Project.
  *
- * @version $Id$
  * @since 1.17
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/response/JacksonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JacksonResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/JacksonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JacksonResponse.java
@@ -43,7 +43,6 @@ import lombok.EqualsAndHashCode;
 /**
  * A JSON response provided by the Jackson Project.
  *
- * @author Borislav Borisov (bborisov@protonmail.com)
  * @version $Id$
  * @since 1.17
  */

--- a/src/main/java/com/jcabi/http/response/JacksonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JacksonResponse.java
@@ -70,6 +70,8 @@ public final class JacksonResponse extends AbstractResponse {
 
     /**
      * A tree representation views of JSON documents.
+     *
+     * @since 1.17.1
      */
     public static final class JsonReader {
         /**

--- a/src/main/java/com/jcabi/http/response/JsonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsonResponse.java
@@ -59,7 +59,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  */

--- a/src/main/java/com/jcabi/http/response/JsonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsonResponse.java
@@ -32,7 +32,7 @@ package com.jcabi.http.response;
 import com.jcabi.aspects.Immutable;
 import com.jcabi.http.Response;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.json.Json;
@@ -100,11 +100,7 @@ public final class JsonResponse extends AbstractResponse {
     public JsonReader json() {
         final byte[] body = this.binary();
         final String json;
-        try {
-            json = new String(body, "UTF-8");
-        } catch (final UnsupportedEncodingException ex) {
-            throw new IllegalStateException(ex);
-        }
+        json = new String(body, StandardCharsets.UTF_8);
         return new JsonResponse.VerboseReader(
             Json.createReader(
                 new StringReader(
@@ -137,16 +133,21 @@ public final class JsonResponse extends AbstractResponse {
 
     /**
      * Verbose reader.
+     *
+     * @since 1.3.1
      */
     private static final class VerboseReader implements JsonReader {
+
         /**
          * Original reader.
          */
         private final transient JsonReader origin;
+
         /**
          * JSON body.
          */
         private final transient String json;
+
         /**
          * Ctor.
          * @param reader Original reader
@@ -156,6 +157,7 @@ public final class JsonResponse extends AbstractResponse {
             this.origin = reader;
             this.json = body;
         }
+
         @Override
         public JsonObject readObject() {
             try {
@@ -166,6 +168,7 @@ public final class JsonResponse extends AbstractResponse {
                 );
             }
         }
+
         @Override
         public JsonArray readArray() {
             try {
@@ -176,6 +179,7 @@ public final class JsonResponse extends AbstractResponse {
                 );
             }
         }
+
         @Override
         public JsonStructure read() {
             try {
@@ -186,6 +190,7 @@ public final class JsonResponse extends AbstractResponse {
                 );
             }
         }
+
         @Override
         public void close() {
             this.origin.close();

--- a/src/main/java/com/jcabi/http/response/JsonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsonResponse.java
@@ -59,7 +59,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/response/JsonResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsonResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/JsoupResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsoupResponse.java
@@ -60,7 +60,6 @@ import org.jsoup.nodes.Entities;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.4
  * @see <a href="http://jsoup.org/">Jsoup website</a>

--- a/src/main/java/com/jcabi/http/response/JsoupResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsoupResponse.java
@@ -60,7 +60,6 @@ import org.jsoup.nodes.Entities;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.4
  * @see <a href="http://jsoup.org/">Jsoup website</a>
  */

--- a/src/main/java/com/jcabi/http/response/JsoupResponse.java
+++ b/src/main/java/com/jcabi/http/response/JsoupResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/RestResponse.java
+++ b/src/main/java/com/jcabi/http/response/RestResponse.java
@@ -67,7 +67,6 @@ import org.hamcrest.Matchers;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  */

--- a/src/main/java/com/jcabi/http/response/RestResponse.java
+++ b/src/main/java/com/jcabi/http/response/RestResponse.java
@@ -312,12 +312,16 @@ public final class RestResponse extends AbstractResponse {
 
     /**
      * Status matcher.
+     *
+     * @since 1.2
      */
     private static final class StatusMatch extends CustomMatcher<Response> {
+
         /**
          * HTTP status to check.
          */
         private final transient int status;
+
         /**
          * Ctor.
          * @param msg Message to show
@@ -327,6 +331,7 @@ public final class RestResponse extends AbstractResponse {
             super(msg);
             this.status = sts;
         }
+
         @Override
         public boolean matches(final Object resp) {
             return Response.class.cast(resp).status() == this.status;

--- a/src/main/java/com/jcabi/http/response/RestResponse.java
+++ b/src/main/java/com/jcabi/http/response/RestResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/RestResponse.java
+++ b/src/main/java/com/jcabi/http/response/RestResponse.java
@@ -67,7 +67,6 @@ import org.hamcrest.Matchers;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
+++ b/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
@@ -134,6 +134,8 @@ public final class WebLinkingResponse extends AbstractResponse {
 
     /**
      * Single link.
+     *
+     * @since 1.0
      */
     @Immutable
     public interface Link extends Map<String, String> {
@@ -146,10 +148,13 @@ public final class WebLinkingResponse extends AbstractResponse {
 
     /**
      * Implementation of a link.
+     *
+     * @since 1.0
      */
     @Immutable
     @EqualsAndHashCode
     private static final class SimpleLink implements WebLinkingResponse.Link {
+
         /**
          * Pattern to match link value.
          */
@@ -157,10 +162,12 @@ public final class WebLinkingResponse extends AbstractResponse {
         private static final Pattern PTN = Pattern.compile(
             "<([^>]+)>\\s*;(.*)"
         );
+
         /**
          * URI encapsulated.
          */
         private final transient String addr;
+
         /**
          * Map of link params.
          */

--- a/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
+++ b/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
@@ -61,7 +61,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.9
  * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988 "Web Linking"</a>

--- a/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
+++ b/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
@@ -61,7 +61,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.9
  * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988 "Web Linking"</a>
  */

--- a/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
+++ b/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
+++ b/src/main/java/com/jcabi/http/response/WebLinkingResponse.java
@@ -167,86 +167,139 @@ public final class WebLinkingResponse extends AbstractResponse {
          * Map of link params.
          */
         private final transient ArrayMap<String, String> params;
+
         /**
          * Public ctor (parser).
          * @param text Text to parse
          * @throws IOException If fails
          */
         SimpleLink(final String text) throws IOException {
-            final Matcher matcher = WebLinkingResponse.SimpleLink.PTN
-                .matcher(text);
+            this(WebLinkingResponse.SimpleLink.parse(text));
+        }
+
+        /**
+         * Secondary ctor.
+         * @param matcher Matcher object.
+         */
+        private SimpleLink(final Matcher matcher) {
+            this(
+                matcher.group(1),
+                WebLinkingResponse.SimpleLink.parseParameters(matcher.group(2))
+            );
+        }
+
+        /**
+         * Primary ctor.
+         * @param address Address
+         * @param parameters Parameters
+         */
+        private SimpleLink(final String address,
+            final Map<String, String> parameters) {
+            this.addr = address;
+            this.params = new ArrayMap<>(parameters);
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create(this.addr);
+        }
+
+        @Override
+        public int size() {
+            return this.params.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.params.isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(final Object key) {
+            return this.params.containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(final Object value) {
+            return this.params.containsValue(value);
+        }
+
+        @Override
+        public String get(final Object key) {
+            return this.params.get(key);
+        }
+
+        @Override
+        public String put(final String key, final String value) {
+            throw new UnsupportedOperationException("#put()");
+        }
+
+        @Override
+        public String remove(final Object key) {
+            throw new UnsupportedOperationException("#remove()");
+        }
+
+        @Override
+        public void putAll(final Map<? extends String, ? extends String> map) {
+            throw new UnsupportedOperationException("#putAll()");
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException("#clear()");
+        }
+
+        @Override
+        public Set<String> keySet() {
+            return this.params.keySet();
+        }
+
+        @Override
+        public Collection<String> values() {
+            return this.params.values();
+        }
+
+        @Override
+        public Set<Map.Entry<String, String>> entrySet() {
+            return this.params.entrySet();
+        }
+
+        /**
+         * Match link with regexp.
+         * @param link A link.
+         * @return Matcher object
+         * @throws IOException If fails
+         */
+        private static Matcher parse(final String link) throws IOException {
+            final Matcher matcher = SimpleLink.PTN.matcher(link);
             if (!matcher.matches()) {
                 throw new IOException(
                     String.format(
                         "Link header value doesn't comply to RFC-5988: \"%s\"",
-                        text
+                        matcher
                     )
                 );
             }
-            this.addr = matcher.group(1);
+            return matcher;
+        }
+
+        /**
+         * Parse parameter string to map.
+         * @param param Result of regexp matching
+         * @return Map with parameters
+         */
+        private static Map<String, String> parseParameters(final String param) {
             final ConcurrentMap<String, String> args =
                 new ConcurrentHashMap<>(0);
             for (final String pair
-                : matcher.group(2).trim().split("\\s*;\\s*")) {
+                : param.trim().split("\\s*;\\s*")) {
                 final String[] parts = pair.split("=");
                 args.put(
                     parts[0].trim().toLowerCase(Locale.ENGLISH),
                     parts[1].trim().replaceAll("(^\"|\"$)", "")
                 );
             }
-            this.params = new ArrayMap<>(args);
-        }
-        @Override
-        public URI uri() {
-            return URI.create(this.addr);
-        }
-        @Override
-        public int size() {
-            return this.params.size();
-        }
-        @Override
-        public boolean isEmpty() {
-            return this.params.isEmpty();
-        }
-        @Override
-        public boolean containsKey(final Object key) {
-            return this.params.containsKey(key);
-        }
-        @Override
-        public boolean containsValue(final Object value) {
-            return this.params.containsValue(value);
-        }
-        @Override
-        public String get(final Object key) {
-            return this.params.get(key);
-        }
-        @Override
-        public String put(final String key, final String value) {
-            throw new UnsupportedOperationException("#put()");
-        }
-        @Override
-        public String remove(final Object key) {
-            throw new UnsupportedOperationException("#remove()");
-        }
-        @Override
-        public void putAll(final Map<? extends String, ? extends String> map) {
-            throw new UnsupportedOperationException("#putAll()");
-        }
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException("#clear()");
-        }
-        @Override
-        public Set<String> keySet() {
-            return this.params.keySet();
-        }
-        @Override
-        public Collection<String> values() {
-            return this.params.values();
-        }
-        @Override
-        public Set<Map.Entry<String, String>> entrySet() {
-            return this.params.entrySet();
+            return args;
         }
     }
 

--- a/src/main/java/com/jcabi/http/response/XmlResponse.java
+++ b/src/main/java/com/jcabi/http/response/XmlResponse.java
@@ -73,7 +73,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.8
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/response/XmlResponse.java
+++ b/src/main/java/com/jcabi/http/response/XmlResponse.java
@@ -73,7 +73,6 @@ import lombok.EqualsAndHashCode;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.8
  */

--- a/src/main/java/com/jcabi/http/response/XmlResponse.java
+++ b/src/main/java/com/jcabi/http/response/XmlResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/package-info.java
+++ b/src/main/java/com/jcabi/http/response/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Responses.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.response;

--- a/src/main/java/com/jcabi/http/response/package-info.java
+++ b/src/main/java/com/jcabi/http/response/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/response/package-info.java
+++ b/src/main/java/com/jcabi/http/response/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Responses.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * This is the base class to handle http responses with 304 state.
  *
- * @author Ievgen Degtiarenko (ievgen.degtiarenko@gmail.com)
  * @version $Id$
  * @since 2.0
  */

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * This is the base class to handle http responses with 304 state.
  *
- * @version $Id$
  * @since 2.0
  */
 public abstract class AbstractHeaderBasedCachingWire implements Wire {

--- a/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AbstractHeaderBasedCachingWire.java
@@ -204,6 +204,7 @@ public abstract class AbstractHeaderBasedCachingWire implements Wire {
         );
         return map.entrySet();
     }
+
     /**
      * Check if the request send through this Wire has the cmch header.
      * @param headers The headers of the request.

--- a/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
@@ -65,7 +65,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.6
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
@@ -65,8 +65,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Carlos Miranda (miranda.cma@gmail.com)
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.6
  */

--- a/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
+++ b/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2617">RFC 2617 "HTTP Authentication: Basic and Digest Access Authentication"</a>
  */

--- a/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
+++ b/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
+++ b/src/main/java/com/jcabi/http/wire/BasicAuthWire.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2617">RFC 2617 "HTTP Authentication: Basic and Digest Access Authentication"</a>

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -76,7 +76,7 @@ import lombok.ToString;
  */
 @Immutable
 @ToString
-@EqualsAndHashCode(of = { "origin", "regex" })
+@EqualsAndHashCode(of = {"origin", "regex"})
 public final class CachingWire implements Wire {
 
     /**
@@ -139,11 +139,11 @@ public final class CachingWire implements Wire {
     // @checkstyle ParameterNumber (5 lines)
     @Override
     public Response send(final Request req, final String home,
-        final String method,
-        final Collection<Map.Entry<String, String>> headers,
-        final InputStream content,
-        final int connect,
-        final int read) throws IOException {
+                         final String method,
+                         final Collection<Map.Entry<String, String>> headers,
+                         final InputStream content,
+                         final int connect,
+                         final int read) throws IOException {
         final URI uri = req.uri().get();
         final StringBuilder label = new StringBuilder(Tv.HUNDRED)
             .append(method).append(' ').append(uri.getPath());
@@ -189,34 +189,42 @@ public final class CachingWire implements Wire {
 
     /**
      * Query.
+     *
+     * @since 1.8.3
      */
     @ToString
-    @EqualsAndHashCode(of = { "origin", "request", "uri", "headers" })
+    @EqualsAndHashCode(of = {"origin", "request", "uri", "headers"})
     private static final class Query {
         /**
          * Origin wire.
          */
         private final transient Wire origin;
+
         /**
          * Request.
          */
         private final transient Request request;
+
         /**
          * URI.
          */
         private final transient String uri;
+
         /**
          * Headers.
          */
         private final transient Collection<Map.Entry<String, String>> headers;
+
         /**
          * Body.
          */
         private final transient InputStream body;
+
         /**
          * Connect timeout.
          */
         private final transient int connect;
+
         /**
          * Read timeout.
          */
@@ -245,6 +253,7 @@ public final class CachingWire implements Wire {
             this.connect = cnct;
             this.read = rdd;
         }
+
         /**
          * Fetch.
          * @return Response

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -72,7 +72,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.0
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -184,6 +184,7 @@ public final class CachingWire implements Wire {
      * Invalidate the entire cache.
      * @since 1.15
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static void invalidate() {
         CachingWire.CACHE.invalidateAll();
     }

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -72,7 +72,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -139,11 +139,11 @@ public final class CachingWire implements Wire {
     // @checkstyle ParameterNumber (5 lines)
     @Override
     public Response send(final Request req, final String home,
-                         final String method,
-                         final Collection<Map.Entry<String, String>> headers,
-                         final InputStream content,
-                         final int connect,
-                         final int read) throws IOException {
+        final String method,
+        final Collection<Map.Entry<String, String>> headers,
+        final InputStream content,
+        final int connect,
+        final int read) throws IOException {
         final URI uri = req.uri().get();
         final StringBuilder label = new StringBuilder(Tv.HUNDRED)
             .append(method).append(' ').append(uri.getPath());

--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
@@ -67,7 +67,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2965">RFC 2965 "HTTP State Management Mechanism"</a>

--- a/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
@@ -67,7 +67,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2965">RFC 2965 "HTTP State Management Mechanism"</a>
  */

--- a/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CookieOptimizingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
@@ -55,7 +55,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 2.0
  */
 @ToString

--- a/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
@@ -55,7 +55,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Ievgen Degtiarenko (ievgen.degtiarenko@gmail.com)
  * @version $Id$
  * @since 2.0
  */

--- a/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/ETagCachingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -63,7 +63,6 @@ import org.apache.commons.io.FileUtils;
 /**
  * Cache for FcWire.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.16
  */

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -39,7 +39,6 @@ import com.jcabi.immutable.Array;
 import com.jcabi.log.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -227,7 +227,7 @@ final class FcCache {
         if (file.getParentFile().mkdirs()) {
             Logger.debug(this, "directory created for %s", file);
         }
-        try (final OutputStream out = new FileOutputStream(file)) {
+        try (OutputStream out = new FileOutputStream(file)) {
             Json.createWriter(out).write(json.build());
         }
         Logger.debug(this, "cache saved into %s", file);

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -63,7 +63,6 @@ import org.apache.commons.io.FileUtils;
 /**
  * Cache for FcWire.
  *
- * @version $Id$
  * @since 1.16
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -65,12 +66,32 @@ import org.apache.commons.io.FileUtils;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.16
- * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
 @Immutable
 @ToString
 @EqualsAndHashCode
+@SuppressWarnings("PMD.ExcessiveImports")
 final class FcCache {
+
+    /**
+     * Body key.
+     */
+    private static final String BODY = "body";
+
+    /**
+     * Status key.
+     */
+    private static final String STATUS = "status";
+
+    /**
+     * Reason key.
+     */
+    private static final String REASON = "reason";
+
+    /**
+     * Headers key.
+     */
+    private static final String HEADERS = "headers";
 
     /**
      * Directory to keep files in.
@@ -165,7 +186,7 @@ final class FcCache {
             )
         ).readObject();
         final List<Map.Entry<String, String>> map = new LinkedList<>();
-        final JsonObject headers = json.getJsonObject("headers");
+        final JsonObject headers = json.getJsonObject(FcCache.HEADERS);
         for (final String name : headers.keySet()) {
             for (final JsonString value
                 : headers.getJsonArray(name).getValuesAs(JsonString.class)) {
@@ -175,10 +196,10 @@ final class FcCache {
         Logger.debug(this, "cache loaded from %s", file);
         return new DefaultResponse(
             req,
-            json.getInt("status"),
-            json.getString("reason"),
+            json.getInt(FcCache.STATUS),
+            json.getString(FcCache.REASON),
             new Array<>(map),
-            json.getString("body").getBytes("UTF-8")
+            json.getString(FcCache.BODY).getBytes(StandardCharsets.UTF_8)
         );
     }
 
@@ -192,8 +213,8 @@ final class FcCache {
     private Response saved(final Response response, final File file)
         throws IOException {
         final JsonObjectBuilder json = Json.createObjectBuilder();
-        json.add("status", response.status());
-        json.add("reason", response.reason());
+        json.add(FcCache.STATUS, response.status());
+        json.add(FcCache.REASON, response.reason());
         final JsonObjectBuilder headers = Json.createObjectBuilder();
         for (final Map.Entry<String, List<String>> pair
             : response.headers().entrySet()) {
@@ -203,8 +224,8 @@ final class FcCache {
             }
             headers.add(pair.getKey(), array);
         }
-        json.add("headers", headers);
-        json.add("body", response.body());
+        json.add(FcCache.HEADERS, headers);
+        json.add(FcCache.BODY, response.body());
         if (file.getParentFile().mkdirs()) {
             Logger.debug(this, "directory created for %s", file);
         }
@@ -224,7 +245,7 @@ final class FcCache {
         final String path;
         try {
             path = Joiner.on("/").join(
-                URLEncoder.encode(label, "UTF-8")
+                URLEncoder.encode(label, StandardCharsets.UTF_8.toString())
                     .replaceAll("_", "__")
                     .replaceAll("\\+", "_")
                     .replaceAll("%", "_")

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/FcCache.java
+++ b/src/main/java/com/jcabi/http/wire/FcCache.java
@@ -46,6 +46,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -227,7 +228,7 @@ final class FcCache {
         if (file.getParentFile().mkdirs()) {
             Logger.debug(this, "directory created for %s", file);
         }
-        try (OutputStream out = new FileOutputStream(file)) {
+        try (OutputStream out = Files.newOutputStream(file.toPath())) {
             Json.createWriter(out).write(json.build());
         }
         Logger.debug(this, "cache saved into %s", file);

--- a/src/main/java/com/jcabi/http/wire/FcWire.java
+++ b/src/main/java/com/jcabi/http/wire/FcWire.java
@@ -68,7 +68,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.16
  */

--- a/src/main/java/com/jcabi/http/wire/FcWire.java
+++ b/src/main/java/com/jcabi/http/wire/FcWire.java
@@ -68,7 +68,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.16
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/FcWire.java
+++ b/src/main/java/com/jcabi/http/wire/FcWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
@@ -36,7 +36,6 @@ import lombok.ToString;
 /**
  * Wire that caches requests based on Last-Modified
  * and If-Modified-Since headers.
- * @version $Id$
  * @since 1.15
  */
 @ToString

--- a/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
@@ -36,7 +36,6 @@ import lombok.ToString;
 /**
  * Wire that caches requests based on Last-Modified
  * and If-Modified-Since headers.
- * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
  * @version $Id$
  * @since 1.15
  */

--- a/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/LastModifiedCachingWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
+++ b/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
@@ -57,7 +57,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
+++ b/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
+++ b/src/main/java/com/jcabi/http/wire/OneMinuteWire.java
@@ -57,7 +57,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -102,14 +102,14 @@ public final class RetryWire implements Wire {
                 if (rsp.status() < HttpURLConnection.HTTP_INTERNAL_ERROR) {
                     return rsp;
                 }
-                if(Logger.isWarnEnabled(this)) {
+                if (Logger.isWarnEnabled(this)) {
                     Logger.warn(
                         this, "%s %s returns %d status (attempt #%d)",
                         method, home, rsp.status(), attempt + 1
                     );
                 }
             } catch (final IOException ex) {
-                if(Logger.isWarnEnabled(this)) {
+                if (Logger.isWarnEnabled(this)) {
                     Logger.warn(
                         this, "%s: %s",
                         ex.getClass().getName(), ex.getLocalizedMessage()

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -102,15 +102,19 @@ public final class RetryWire implements Wire {
                 if (rsp.status() < HttpURLConnection.HTTP_INTERNAL_ERROR) {
                     return rsp;
                 }
-                Logger.warn(
-                    this, "%s %s returns %d status (attempt #%d)",
-                    method, home, rsp.status(), attempt + 1
-                );
+                if(Logger.isWarnEnabled(this)) {
+                    Logger.warn(
+                        this, "%s %s returns %d status (attempt #%d)",
+                        method, home, rsp.status(), attempt + 1
+                    );
+                }
             } catch (final IOException ex) {
-                Logger.warn(
-                    this, "%s: %s",
-                    ex.getClass().getName(), ex.getLocalizedMessage()
-                );
+                if(Logger.isWarnEnabled(this)) {
+                    Logger.warn(
+                        this, "%s: %s",
+                        ex.getClass().getName(), ex.getLocalizedMessage()
+                    );
+                }
             }
             ++attempt;
         }

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -60,7 +60,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -60,7 +60,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/RetryWire.java
+++ b/src/main/java/com/jcabi/http/wire/RetryWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -76,11 +76,13 @@ public final class TrustedWire implements Wire {
         public X509Certificate[] getAcceptedIssuers() {
             return new X509Certificate[0];
         }
+
         @Override
         public void checkClientTrusted(final X509Certificate[] certs,
             final String type) {
             // nothing to check here
         }
+
         @Override
         public void checkServerTrusted(final X509Certificate[] certs,
             final String types) {
@@ -134,13 +136,11 @@ public final class TrustedWire implements Wire {
             final SSLContext ctx = SSLContext.getInstance("SSL");
             ctx.init(
                 null,
-                new TrustManager[] {TrustedWire.MANAGER},
+                new TrustManager[]{TrustedWire.MANAGER},
                 new SecureRandom()
             );
             return ctx;
-        } catch (final KeyManagementException ex) {
-            throw new IllegalStateException(ex);
-        } catch (final NoSuchAlgorithmException ex) {
+        } catch (final KeyManagementException | NoSuchAlgorithmException ex) {
             throw new IllegalStateException(ex);
         }
     }

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -61,7 +61,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 1.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -61,7 +61,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.10
  */

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/UserAgentWire.java
+++ b/src/main/java/com/jcabi/http/wire/UserAgentWire.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2616#section-14.43">RFC 2616 section 14.43 "User-Agent"</a>
  */

--- a/src/main/java/com/jcabi/http/wire/UserAgentWire.java
+++ b/src/main/java/com/jcabi/http/wire/UserAgentWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/UserAgentWire.java
+++ b/src/main/java/com/jcabi/http/wire/UserAgentWire.java
@@ -63,7 +63,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  * @see <a href="http://tools.ietf.org/html/rfc2616#section-14.43">RFC 2616 section 14.43 "User-Agent"</a>

--- a/src/main/java/com/jcabi/http/wire/VerboseWire.java
+++ b/src/main/java/com/jcabi/http/wire/VerboseWire.java
@@ -59,7 +59,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/wire/VerboseWire.java
+++ b/src/main/java/com/jcabi/http/wire/VerboseWire.java
@@ -59,7 +59,6 @@ import lombok.ToString;
  *
  * <p>The class is immutable and thread-safe.
  *
- * @version $Id$
  * @since 0.10
  */
 @Immutable

--- a/src/main/java/com/jcabi/http/wire/VerboseWire.java
+++ b/src/main/java/com/jcabi/http/wire/VerboseWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/package-info.java
+++ b/src/main/java/com/jcabi/http/wire/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Wires.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/main/java/com/jcabi/http/wire/package-info.java
+++ b/src/main/java/com/jcabi/http/wire/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/main/java/com/jcabi/http/wire/package-info.java
+++ b/src/main/java/com/jcabi/http/wire/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Wires.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.wire;

--- a/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
+++ b/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link ImmutableHeader}.
- * @version $Id$
  * @since 1.1
  */
 public final class ImmutableHeaderTest {

--- a/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
+++ b/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link ImmutableHeader}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.1
  */

--- a/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
+++ b/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
+++ b/src/test/java/com/jcabi/http/ImmutableHeaderTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
  * Test case for {@link ImmutableHeader}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 1.1
  */
 public final class ImmutableHeaderTest {
 

--- a/src/test/java/com/jcabi/http/MockWire.java
+++ b/src/test/java/com/jcabi/http/MockWire.java
@@ -40,7 +40,6 @@ import java.util.Map.Entry;
  * <p>
  * NOTE: This is not threadsafe and access to it should be synchronized.
  *
- * @version $Id$
  * @since 1.17.1
  * @checkstyle ParameterNumberCheck (50 lines)
  */

--- a/src/test/java/com/jcabi/http/MockWire.java
+++ b/src/test/java/com/jcabi/http/MockWire.java
@@ -40,7 +40,6 @@ import java.util.Map.Entry;
  * <p>
  * NOTE: This is not threadsafe and access to it should be synchronized.
  *
- * @author Jakob Oswald (jakob.oswald@gmx.net)
  * @version $Id$
  * @since 1.17.1
  * @checkstyle ParameterNumberCheck (50 lines)

--- a/src/test/java/com/jcabi/http/MockWire.java
+++ b/src/test/java/com/jcabi/http/MockWire.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/RequestITCase.java
+++ b/src/test/java/com/jcabi/http/RequestITCase.java
@@ -44,7 +44,6 @@ import org.junit.runners.Parameterized;
 
 /**
  * Integration case for {@link com.jcabi.http.request.ApacheRequest}.
- * @version $Id$
  * @since 1.1
  */
 @RunWith(Parameterized.class)

--- a/src/test/java/com/jcabi/http/RequestITCase.java
+++ b/src/test/java/com/jcabi/http/RequestITCase.java
@@ -46,6 +46,7 @@ import org.junit.runners.Parameterized;
  * Integration case for {@link com.jcabi.http.request.ApacheRequest}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 1.1
  */
 @RunWith(Parameterized.class)
 public final class RequestITCase {

--- a/src/test/java/com/jcabi/http/RequestITCase.java
+++ b/src/test/java/com/jcabi/http/RequestITCase.java
@@ -44,7 +44,6 @@ import org.junit.runners.Parameterized;
 
 /**
  * Integration case for {@link com.jcabi.http.request.ApacheRequest}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.1
  */

--- a/src/test/java/com/jcabi/http/RequestITCase.java
+++ b/src/test/java/com/jcabi/http/RequestITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -46,12 +46,12 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
-import org.apache.commons.lang3.CharEncoding;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -175,7 +175,10 @@ public final class RequestTest {
             .assertStatus(HttpURLConnection.HTTP_OK);
         final MkQuery query = container.take();
         MatcherAssert.assertThat(
-            URLDecoder.decode(query.uri().toString(), CharEncoding.UTF_8),
+            URLDecoder.decode(
+                query.uri().toString(),
+                String.valueOf(StandardCharsets.UTF_8)
+            ),
             Matchers.endsWith("\"€\"")
         );
         container.stop();

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -60,7 +60,6 @@ import org.junit.runners.Parameterized;
 
 /**
  * Test case for {@link Request} and its implementations.
- * @version $Id$
  * @since 1.7
  */
 @SuppressWarnings(

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -60,7 +60,6 @@ import org.junit.runners.Parameterized;
 
 /**
  * Test case for {@link Request} and its implementations.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.7
  */

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -67,10 +67,7 @@ import org.junit.runners.Parameterized;
 @SuppressWarnings(
     {
         "PMD.TooManyMethods",
-        "PMD.DoNotUseThreads",
-        "PMD.AvoidCatchingGenericException",
-        "PMD.AvoidThrowingRawExceptionTypes",
-        "PMD.ExcessiveImports"
+        "PMD.AvoidDuplicateLiterals"
     })
 @RunWith(Parameterized.class)
 public final class RequestTest {

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -62,13 +62,16 @@ import org.junit.runners.Parameterized;
  * Test case for {@link Request} and its implementations.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
- * @checkstyle IndentationCheck (7 lines)
+ * @since 1.7
  */
-@SuppressWarnings({
-    "PMD.TooManyMethods", "PMD.DoNotUseThreads",
-    "PMD.AvoidCatchingGenericException",
-    "PMD.AvoidThrowingRawExceptionTypes", "PMD.ExcessiveImports"
-})
+@SuppressWarnings(
+    {
+        "PMD.TooManyMethods",
+        "PMD.DoNotUseThreads",
+        "PMD.AvoidCatchingGenericException",
+        "PMD.AvoidThrowingRawExceptionTypes",
+        "PMD.ExcessiveImports"
+    })
 @RunWith(Parameterized.class)
 public final class RequestTest {
     /**
@@ -205,7 +208,7 @@ public final class RequestTest {
             .assertStatus(HttpURLConnection.HTTP_OK);
         final MkQuery query = container.take();
         MatcherAssert.assertThat(
-            URLDecoder.decode(query.body(), CharEncoding.UTF_8),
+            URLDecoder.decode(query.body(), StandardCharsets.UTF_8.toString()),
             Matchers.is(String.format("p=%s", value))
         );
         container.stop();
@@ -236,7 +239,7 @@ public final class RequestTest {
             .assertStatus(HttpURLConnection.HTTP_OK);
         final MkQuery query = container.take();
         MatcherAssert.assertThat(
-            URLDecoder.decode(query.body(), CharEncoding.UTF_8),
+            URLDecoder.decode(query.body(), StandardCharsets.UTF_8.toString()),
             Matchers.is(
                 String.format("a=%s&b=%s", value, follow)
             )
@@ -394,12 +397,14 @@ public final class RequestTest {
                 HttpHeaders.CONTENT_TYPE,
                 MediaType.APPLICATION_FORM_URLENCODED
             )
-            .body().set(URLEncoder.encode(value, CharEncoding.UTF_8)).back()
+            .body()
+            .set(URLEncoder.encode(value, StandardCharsets.UTF_8.toString()))
+            .back()
             .fetch().as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK);
         final MkQuery query = container.take();
         MatcherAssert.assertThat(
-            URLDecoder.decode(query.body(), CharEncoding.UTF_8),
+            URLDecoder.decode(query.body(), StandardCharsets.UTF_8.toString()),
             Matchers.containsString(value)
         );
         container.stop();
@@ -627,7 +632,7 @@ public final class RequestTest {
         ).start();
         final String value = "\u20ac body as stream \"&^%*;'\"";
         final ByteArrayInputStream stream =
-            new ByteArrayInputStream(value.getBytes(CharEncoding.UTF_8));
+            new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
         this.request(container.home())
             .method(Request.POST)
             .header(
@@ -654,7 +659,9 @@ public final class RequestTest {
         this.request(new URI("http://localhost:78787"))
             .method(Request.GET)
             .body().set("already set").back()
-            .fetch(new ByteArrayInputStream("ba".getBytes(CharEncoding.UTF_8)));
+            .fetch(
+                new ByteArrayInputStream("ba".getBytes(StandardCharsets.UTF_8))
+            );
     }
 
     /**

--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -40,6 +40,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -120,21 +121,19 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeBody()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .body()
-                        .back()
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .method(Request.GET)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .body()
+                    .back()
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -149,19 +148,17 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeFetch()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .method(Request.GET)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -176,20 +173,21 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeHeader()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .header(CONTENT_TYPE, "text/plain")
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .method(Request.GET)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .header(
+                        RequestTimeoutLossTest.CONTENT_TYPE,
+                        "text/plain"
+                    )
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -204,19 +202,17 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeMethod()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .method(Request.GET)
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .method(Request.GET)
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -231,21 +227,19 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeMultipartBody()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .multipartBody()
-                        .back()
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .method(Request.GET)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .multipartBody()
+                    .back()
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -260,20 +254,18 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeReset()
         throws Exception {
-        final Runnable execution = new Runnable() {
+        final Callable<Response> execution = new Callable<Response>() {
             @Override
-            public void run() {
-                try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
-                        .through(MockWire.class)
-                        .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
-                        .reset(CONTENT_TYPE)
-                        .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
-                }
+            public Response call() throws Exception {
+                return RequestTimeoutLossTest.this.request()
+                    .through(MockWire.class)
+                    .method(Request.GET)
+                    .timeout(
+                        RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                        RequestTimeoutLossTest.READ_TIMEOUT
+                    )
+                    .reset(RequestTimeoutLossTest.CONTENT_TYPE)
+                    .fetch();
             }
         };
         this.testTimeoutOrderDoesntMatter(execution);
@@ -288,24 +280,24 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeUriBack()
         throws Exception {
-        final Runnable execution = new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    RequestTimeoutLossTest.this.request(new URI(LOCALHOST_URL))
+        this.testTimeoutOrderDoesntMatter(
+            new Callable<Response>() {
+                @Override
+                public Response call() throws Exception {
+                    return RequestTimeoutLossTest.this.request()
                         .through(MockWire.class)
                         .method(Request.GET)
-                        .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
+                        .timeout(
+                            RequestTimeoutLossTest.CONNECT_TIMEOUT,
+                            RequestTimeoutLossTest.READ_TIMEOUT
+                        )
                         .uri()
                         .path("/api")
                         .back()
                         .fetch();
-                } catch (final Exception ex) {
-                    throw new RuntimeException(ex);
                 }
             }
-        };
-        this.testTimeoutOrderDoesntMatter(execution);
+        );
     }
 
     /**
@@ -362,11 +354,11 @@ public final class RequestTimeoutLossTest {
      * The connect and read timeouts are properly set no matter in which order
      * <code>Request.timeout</code> is called.
      *
-     * @param execution The runnable that contains the actual request execution
+     * @param exec The callable that contains the actual request
      * @throws Exception If something goes wrong inside
      */
     @SuppressWarnings("unchecked")
-    private void testTimeoutOrderDoesntMatter(final Runnable execution)
+    private void testTimeoutOrderDoesntMatter(final Callable<Response> exec)
         throws Exception {
         synchronized (MockWire.class) {
             final Wire wire = Mockito.mock(Wire.class);
@@ -387,7 +379,7 @@ public final class RequestTimeoutLossTest {
                     Mockito.anyInt()
                 )
             ).thenReturn(response);
-            execution.run();
+            exec.call();
             Mockito.verify(wire).send(
                 Mockito.any(Request.class),
                 Mockito.anyString(),
@@ -399,11 +391,11 @@ public final class RequestTimeoutLossTest {
             );
             MatcherAssert.assertThat(
                 cnc.getValue().intValue(),
-                Matchers.is(CONNECT_TIMEOUT)
+                Matchers.is(RequestTimeoutLossTest.CONNECT_TIMEOUT)
             );
             MatcherAssert.assertThat(
                 rdc.getValue().intValue(),
-                Matchers.is(READ_TIMEOUT)
+                Matchers.is(RequestTimeoutLossTest.READ_TIMEOUT)
             );
         }
     }
@@ -416,6 +408,17 @@ public final class RequestTimeoutLossTest {
      */
     private Request request(final URI uri) throws Exception {
         return this.type.getDeclaredConstructor(URI.class).newInstance(uri);
+    }
+
+    /**
+     * Make a request with default url.
+     * @return Request
+     * @throws Exception If fails
+     */
+    private Request request() throws Exception {
+        return RequestTimeoutLossTest.this.request(
+            new URI(RequestTimeoutLossTest.LOCALHOST_URL)
+        );
     }
 
 }

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -52,7 +52,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for loss of timeout parameters.
- * @author Jakob Oswald (jakob.oswald@gmx.net)
  * @version $Id$
  * @since 1.17.3
  */

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -52,7 +52,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for loss of timeout parameters.
- * @version $Id$
  * @since 1.17.3
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -55,16 +55,8 @@ import org.mockito.Mockito;
  * @author Jakob Oswald (jakob.oswald@gmx.net)
  * @version $Id$
  * @since 1.17.3
- * @checkstyle IllegalCatchCheck (400 lines)
  */
-@SuppressWarnings(
-    {
-        "PMD.TooManyMethods",
-        "PMD.DoNotUseThreads",
-        "PMD.AvoidCatchingGenericException",
-        "PMD.AvoidThrowingRawExceptionTypes"
-    }
-    )
+@SuppressWarnings("PMD.TooManyMethods")
 @RunWith(Parameterized.class)
 public final class RequestTimeoutLossTest {
     /**
@@ -416,7 +408,7 @@ public final class RequestTimeoutLossTest {
      * @throws Exception If fails
      */
     private Request request() throws Exception {
-        return RequestTimeoutLossTest.this.request(
+        return this.request(
             new URI(RequestTimeoutLossTest.LOCALHOST_URL)
         );
     }

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
+++ b/src/test/java/com/jcabi/http/RequestTimeoutLossTest.java
@@ -54,12 +54,16 @@ import org.mockito.Mockito;
  * @author Jakob Oswald (jakob.oswald@gmx.net)
  * @version $Id$
  * @since 1.17.3
+ * @checkstyle IllegalCatchCheck (400 lines)
  */
-@SuppressWarnings({
-    "PMD.TooManyMethods", "PMD.DoNotUseThreads",
-    "PMD.AvoidCatchingGenericException",
-    "PMD.AvoidThrowingRawExceptionTypes"
-})
+@SuppressWarnings(
+    {
+        "PMD.TooManyMethods",
+        "PMD.DoNotUseThreads",
+        "PMD.AvoidCatchingGenericException",
+        "PMD.AvoidThrowingRawExceptionTypes"
+    }
+    )
 @RunWith(Parameterized.class)
 public final class RequestTimeoutLossTest {
     /**
@@ -116,7 +120,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeBody()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -128,13 +132,12 @@ public final class RequestTimeoutLossTest {
                         .body()
                         .back()
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -146,7 +149,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeFetch()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -156,13 +159,12 @@ public final class RequestTimeoutLossTest {
                         .method(Request.GET)
                         .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -174,7 +176,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeHeader()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -185,13 +187,12 @@ public final class RequestTimeoutLossTest {
                         .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
                         .header(CONTENT_TYPE, "text/plain")
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -203,7 +204,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeMethod()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -213,13 +214,12 @@ public final class RequestTimeoutLossTest {
                         .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
                         .method(Request.GET)
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -231,7 +231,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeMultipartBody()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -243,13 +243,12 @@ public final class RequestTimeoutLossTest {
                         .multipartBody()
                         .back()
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -261,7 +260,7 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeReset()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -272,13 +271,12 @@ public final class RequestTimeoutLossTest {
                         .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
                         .reset(CONTENT_TYPE)
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -290,12 +288,11 @@ public final class RequestTimeoutLossTest {
     @Test
     public void testTimeoutOrderDoesntMatterBeforeUriBack()
         throws Exception {
-        final Runnable requestExecution = new Runnable() {
+        final Runnable execution = new Runnable() {
             @Override
             public void run() {
                 try {
-                    // @checkstyle RequireThisCheck (1 lines)
-                    request(new URI(LOCALHOST_URL))
+                    RequestTimeoutLossTest.this.request(new URI(LOCALHOST_URL))
                         .through(MockWire.class)
                         .method(Request.GET)
                         .timeout(CONNECT_TIMEOUT, READ_TIMEOUT)
@@ -303,13 +300,12 @@ public final class RequestTimeoutLossTest {
                         .path("/api")
                         .back()
                         .fetch();
-                    // @checkstyle IllegalCatchCheck (1 lines)
                 } catch (final Exception ex) {
                     throw new RuntimeException(ex);
                 }
             }
         };
-        this.testTimeoutOrderDoesntMatter(requestExecution);
+        this.testTimeoutOrderDoesntMatter(execution);
     }
 
     /**
@@ -373,15 +369,15 @@ public final class RequestTimeoutLossTest {
     private void testTimeoutOrderDoesntMatter(final Runnable execution)
         throws Exception {
         synchronized (MockWire.class) {
-            final Wire mockWire = Mockito.mock(Wire.class);
-            final ArgumentCaptor<Integer> connectCaptor = ArgumentCaptor
+            final Wire wire = Mockito.mock(Wire.class);
+            final ArgumentCaptor<Integer> cnc = ArgumentCaptor
                 .forClass(Integer.class);
-            final ArgumentCaptor<Integer> readCaptor = ArgumentCaptor
+            final ArgumentCaptor<Integer> rdc = ArgumentCaptor
                 .forClass(Integer.class);
-            MockWire.setMockDelegate(mockWire);
-            final Response mockResponse = Mockito.mock(Response.class);
+            MockWire.setMockDelegate(wire);
+            final Response response = Mockito.mock(Response.class);
             Mockito.when(
-                mockWire.send(
+                wire.send(
                     Mockito.any(Request.class),
                     Mockito.anyString(),
                     Mockito.anyString(),
@@ -390,23 +386,23 @@ public final class RequestTimeoutLossTest {
                     Mockito.anyInt(),
                     Mockito.anyInt()
                 )
-            ).thenReturn(mockResponse);
+            ).thenReturn(response);
             execution.run();
-            Mockito.verify(mockWire).send(
+            Mockito.verify(wire).send(
                 Mockito.any(Request.class),
                 Mockito.anyString(),
                 Mockito.anyString(),
                 Mockito.<Map.Entry<String, String>>anyCollection(),
                 Mockito.any(InputStream.class),
-                connectCaptor.capture(),
-                readCaptor.capture()
+                cnc.capture(),
+                rdc.capture()
             );
             MatcherAssert.assertThat(
-                connectCaptor.getValue().intValue(),
+                cnc.getValue().intValue(),
                 Matchers.is(CONNECT_TIMEOUT)
             );
             MatcherAssert.assertThat(
-                readCaptor.getValue().intValue(),
+                rdc.getValue().intValue(),
                 Matchers.is(READ_TIMEOUT)
             );
         }

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -75,10 +75,12 @@ public final class GrizzlyQueryTest {
          * Bytes to be returned by the stream.
          */
         private final transient byte[] bytes;
+
         /**
          * Is it empty?
          */
         private transient boolean empty;
+
         /**
          * Ctor.
          * @param bts Bytes
@@ -87,6 +89,7 @@ public final class GrizzlyQueryTest {
             super(new GrizzlyInputBuffer());
             this.bytes = Arrays.copyOf(bts, bts.length);
         }
+
         @Override
         public int read(final byte[] bts) throws IOException {
             int length = -1;

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -42,7 +42,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link GrizzlyQuery}.
- * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
  * @since 1.13
  */

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -69,6 +69,8 @@ public final class GrizzlyQueryTest {
 
     /**
      * Mock for GrizzlyInputStream, which returns desired byte array.
+     *
+     * @since 1.13
      */
     private static class MkGrizzlyInputStream extends GrizzlyInputStream {
         /**

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -42,7 +42,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link GrizzlyQuery}.
- * @version $Id$
  * @since 1.13
  */
 public final class GrizzlyQueryTest {

--- a/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
+++ b/src/test/java/com/jcabi/http/mock/GrizzlyQueryTest.java
@@ -44,6 +44,7 @@ import org.mockito.Mockito;
  * Test case for {@link GrizzlyQuery}.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 1.13
  */
 public final class GrizzlyQueryTest {
 

--- a/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
@@ -68,10 +68,10 @@ public final class MkAnswerMatchersTest {
         final MkAnswer query = Mockito.mock(MkAnswer.class);
         Mockito.doReturn(body).when(query).bodyBytes();
         MatcherAssert.assertThat(
-                query,
-                MkAnswerMatchers.hasBodyBytes(
-                        Matchers.is(body)
-                )
+            query,
+            MkAnswerMatchers.hasBodyBytes(
+                Matchers.is(body)
+            )
         );
     }
 

--- a/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
  * Test case for {@link MkAnswerMatchers}.
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
+ * @since 1.5
  */
 public final class MkAnswerMatchersTest {
 

--- a/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link MkAnswerMatchers}.
- * @version $Id$
  * @since 1.5
  */
 public final class MkAnswerMatchersTest {

--- a/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link MkAnswerMatchers}.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkAnswerMatchersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -54,7 +54,7 @@ public final class MkContainerTest {
      */
     @Test
     public void worksAsServletContainer() throws Exception {
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple(HttpURLConnection.HTTP_OK, "works fine!")
             ).start();
@@ -76,7 +76,7 @@ public final class MkContainerTest {
      */
     @Test
     public void understandsDuplicateHeaders() throws Exception {
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(new MkAnswer.Simple("")).start();
             final String header = "X-Something";
             new JdkRequest(container.home())
@@ -101,7 +101,7 @@ public final class MkContainerTest {
     public void answersConditionally() throws Exception {
         final String match = "matching";
         final String mismatch = "not matching";
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple(mismatch),
                 Matchers.not(new IsAnything<MkQuery>())
@@ -127,7 +127,7 @@ public final class MkContainerTest {
     @Test
     public void answersBinary() throws Exception {
         final byte[] body = {0x00, 0x01, 0x45, 0x21, (byte) 0xFF};
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple(HttpURLConnection.HTTP_OK)
                     .withBody(body)
@@ -146,7 +146,7 @@ public final class MkContainerTest {
      */
     @Test(expected = NoSuchElementException.class)
     public void returnsErrorIfNoMatches() throws Exception {
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple("not supposed to match"),
                 Matchers.not(new IsAnything<MkQuery>())
@@ -167,7 +167,7 @@ public final class MkContainerTest {
     public void canAnswerMultipleTimes() throws Exception {
         final String body = "multiple";
         final int times = 5;
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple(body),
                 new IsAnything<MkQuery>(),
@@ -192,7 +192,7 @@ public final class MkContainerTest {
     public void prioritizesMatchingAnswers() throws Exception {
         final String first = "first";
         final String second = "second";
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container
                 .next(new MkAnswer.Simple(first), new IsAnything<MkQuery>())
                 .next(new MkAnswer.Simple(second), new IsAnything<MkQuery>())
@@ -218,7 +218,7 @@ public final class MkContainerTest {
     public void takesMatchingQuery() throws Exception {
         final String request = "reqBodyMatches";
         final String response = "respBodyMatches";
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container
                 .next(new MkAnswer.Simple(response))
                 .next(new MkAnswer.Simple("bleh"))
@@ -252,7 +252,7 @@ public final class MkContainerTest {
         final String match = "multipleRequestMatches";
         final String mismatch = "multipleRequestNotMatching";
         final String response = "multipleResponseMatches";
-        try (final MkContainer container = new MkGrizzlyContainer()) {
+        try (MkContainer container = new MkGrizzlyContainer()) {
             container.next(
                 new MkAnswer.Simple(response),
                 MkQueryMatchers.hasBody(Matchers.is(match)),

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link MkContainer}.
- * @version $Id$
  * @since 1.0
  */
 public final class MkContainerTest {

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link MkContainer}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * Test case for {@link MkContainer}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 1.0
  */
 public final class MkContainerTest {
 
@@ -130,14 +131,14 @@ public final class MkContainerTest {
         final byte[] body = {0x00, 0x01, 0x45, 0x21, (byte) 0xFF};
         try (final MkContainer container = new MkGrizzlyContainer()) {
             container.next(
-                    new MkAnswer.Simple(HttpURLConnection.HTTP_OK)
-                            .withBody(body)
-                    ).start();
+                new MkAnswer.Simple(HttpURLConnection.HTTP_OK)
+                    .withBody(body)
+            ).start();
             new JdkRequest(container.home())
-                    .through(VerboseWire.class)
-                    .fetch().as(RestResponse.class)
-                    .assertStatus(HttpURLConnection.HTTP_OK)
-                    .assertBinary(Matchers.is(body));
+                .through(VerboseWire.class)
+                .fetch().as(RestResponse.class)
+                .assertStatus(HttpURLConnection.HTTP_OK)
+                .assertBinary(Matchers.is(body));
         }
     }
 

--- a/src/test/java/com/jcabi/http/mock/MkContainerTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkContainerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
  * Test case for {@link MkQueryMatchers}.
  * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
+ * @since 1.5
  */
 public final class MkQueryMatchersTest {
 

--- a/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link MkQueryMatchers}.
- * @version $Id$
  * @since 1.5
  */
 public final class MkQueryMatchersTest {

--- a/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
+++ b/src/test/java/com/jcabi/http/mock/MkQueryMatchersTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link MkQueryMatchers}.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.5
  */

--- a/src/test/java/com/jcabi/http/mock/package-info.java
+++ b/src/test/java/com/jcabi/http/mock/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Mock of Servlet Container, tests.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.mock;

--- a/src/test/java/com/jcabi/http/mock/package-info.java
+++ b/src/test/java/com/jcabi/http/mock/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Mock of Servlet Container, tests.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/test/java/com/jcabi/http/mock/package-info.java
+++ b/src/test/java/com/jcabi/http/mock/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/package-info.java
+++ b/src/test/java/com/jcabi/http/package-info.java
@@ -30,6 +30,5 @@
 
 /**
  * Test package, tests for it.
- *
  */
 package com.jcabi.http;

--- a/src/test/java/com/jcabi/http/package-info.java
+++ b/src/test/java/com/jcabi/http/package-info.java
@@ -31,6 +31,5 @@
 /**
  * Test package, tests for it.
  *
- * @version $Id$
  */
 package com.jcabi.http;

--- a/src/test/java/com/jcabi/http/package-info.java
+++ b/src/test/java/com/jcabi/http/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Test package, tests for it.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
 package com.jcabi.http;

--- a/src/test/java/com/jcabi/http/package-info.java
+++ b/src/test/java/com/jcabi/http/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/BaseRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/BaseRequestTest.java
@@ -43,7 +43,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link BaseRequest}.
- * @version $Id$
  * @since 1.0
  */
 public final class BaseRequestTest {

--- a/src/test/java/com/jcabi/http/request/BaseRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/BaseRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/BaseRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/BaseRequestTest.java
@@ -43,7 +43,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link BaseRequest}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/request/BoundaryTest.java
+++ b/src/test/java/com/jcabi/http/request/BoundaryTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 /**
  * Test case {@link Boundary}.
- * @version $Id$
  * @since 1.17.3
  */
 public final class BoundaryTest {

--- a/src/test/java/com/jcabi/http/request/BoundaryTest.java
+++ b/src/test/java/com/jcabi/http/request/BoundaryTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 /**
  * Test case {@link Boundary}.
- * @author Piotr Kotlicki (piotr.kotlicki@gmail.com)
  * @version $Id$
  * @since 1.17.3
  */

--- a/src/test/java/com/jcabi/http/request/BoundaryTest.java
+++ b/src/test/java/com/jcabi/http/request/BoundaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
+++ b/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
+++ b/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
@@ -38,7 +38,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link DefaultResponse}.
- * @version $Id$
  * @since 1.0
  */
 public final class DefaultResponseTest {

--- a/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
+++ b/src/test/java/com/jcabi/http/request/DefaultResponseTest.java
@@ -38,7 +38,6 @@ import org.mockito.Mockito;
 
 /**
  * Test case for {@link DefaultResponse}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FakeRequest}.
- * @version $Id$
  * @since 1.0
  */
 public final class FakeRequestTest {

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -129,7 +129,7 @@ public final class FakeRequestTest {
     /**
      * FakeRequest returns the Response Body if the Request Body is set.
      * @throws Exception If something goes wrong inside.
-     * @see https://github.com/jcabi/jcabi-http/issues/47
+     * @link https://github.com/jcabi/jcabi-http/issues/47
      */
     @Test
     public void fakeRequestReturnsResponseBody() throws Exception {

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/FakeRequestTest.java
+++ b/src/test/java/com/jcabi/http/request/FakeRequestTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FakeRequest}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
+++ b/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
+++ b/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
@@ -42,7 +42,6 @@ import org.junit.rules.ExpectedException;
 
 /**
  * Integration case for {@link JdkRequest}.
- * @version $Id$
  * @since 1.4.1
  */
 public final class JdkRequestITCase {

--- a/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
+++ b/src/test/java/com/jcabi/http/request/JdkRequestITCase.java
@@ -42,7 +42,6 @@ import org.junit.rules.ExpectedException;
 
 /**
  * Integration case for {@link JdkRequest}.
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.4.1
  */

--- a/src/test/java/com/jcabi/http/request/package-info.java
+++ b/src/test/java/com/jcabi/http/request/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Requests, tests.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/test/java/com/jcabi/http/request/package-info.java
+++ b/src/test/java/com/jcabi/http/request/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Requests, tests.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.request;

--- a/src/test/java/com/jcabi/http/request/package-info.java
+++ b/src/test/java/com/jcabi/http/request/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 /**
  * Test case for {@link JacksonResponse}.
  *
- * @version $Id$
  * @since 1.17
  */
 public final class JacksonResponseTest {

--- a/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 /**
  * Test case for {@link JacksonResponse}.
  *
- * @author Borislav Borisov (bborisov@protonmail.com)
  * @version $Id$
  * @since 1.17
  */

--- a/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JacksonResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/JsonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsonResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link JsonResponse}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.1
  */

--- a/src/test/java/com/jcabi/http/response/JsonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsonResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link JsonResponse}.
- * @version $Id$
  * @since 1.1
  */
 public final class JsonResponseTest {

--- a/src/test/java/com/jcabi/http/response/JsonResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsonResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 /**
  * Test case for {@link JsoupResponse}.
  *
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.4
  */

--- a/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 /**
  * Test case for {@link JsoupResponse}.
  *
- * @version $Id$
  * @since 1.4
  */
 public final class JsoupResponseTest {

--- a/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/JsoupResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/RestResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/RestResponseTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RestResponse}.
- * @version $Id$
  * @since 1.1
  */
 public final class RestResponseTest {

--- a/src/test/java/com/jcabi/http/response/RestResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/RestResponseTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RestResponse}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.1
  */

--- a/src/test/java/com/jcabi/http/response/RestResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/RestResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link WebLinkingResponse}.
- * @version $Id$
  * @since 0.9
  */
 public final class WebLinkingResponseTest {

--- a/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link WebLinkingResponse}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.9
  */

--- a/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
@@ -40,9 +40,13 @@ import org.junit.Test;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.9
- * @checkstyle MultipleStringLiterals (500 lines)
  */
 public final class WebLinkingResponseTest {
+
+    /**
+     * The Link header.
+     */
+    private static final String LINK = "Link";
 
     /**
      * WebLinkingResponse can recognize Links in headers.
@@ -57,7 +61,9 @@ public final class WebLinkingResponseTest {
         };
         for (final String header : headers) {
             final WebLinkingResponse response = new WebLinkingResponse(
-                new FakeRequest().withHeader("Link", header).fetch()
+                new FakeRequest()
+                    .withHeader(WebLinkingResponseTest.LINK, header)
+                    .fetch()
             );
             final WebLinkingResponse.Link link = response.links().get("foo");
             MatcherAssert.assertThat(
@@ -83,7 +89,7 @@ public final class WebLinkingResponseTest {
     public void followsLinksInHeaders() throws Exception {
         final WebLinkingResponse response = new WebLinkingResponse(
             new FakeRequest().withHeader(
-                "Link",
+                WebLinkingResponseTest.LINK,
                 "</a>; rel=\"first\", <http://localhost/o>; rel=\"second\""
             ).uri().set(new URI("http://localhost/test")).back().fetch()
         );

--- a/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/WebLinkingResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/XmlResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/XmlResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XmlResponse}.
- * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @since 1.1
  */

--- a/src/test/java/com/jcabi/http/response/XmlResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/XmlResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/response/XmlResponseTest.java
+++ b/src/test/java/com/jcabi/http/response/XmlResponseTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link XmlResponse}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  * @since 1.1

--- a/src/test/java/com/jcabi/http/response/package-info.java
+++ b/src/test/java/com/jcabi/http/response/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Responses, tests.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.response;

--- a/src/test/java/com/jcabi/http/response/package-info.java
+++ b/src/test/java/com/jcabi/http/response/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Responses, tests.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/test/java/com/jcabi/http/response/package-info.java
+++ b/src/test/java/com/jcabi/http/response/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
@@ -45,7 +45,6 @@ import org.junit.Test;
 /**
  * Test case for {@link AutoRedirectingWire}.
  *
- * @version $Id$
  * @since 1.7
  */
 public final class AutoRedirectingWireTest {

--- a/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
@@ -45,7 +45,6 @@ import org.junit.Test;
 /**
  * Test case for {@link AutoRedirectingWire}.
  *
- * @author Carlos Miranda (miranda.cma@gmail.com)
  * @version $Id$
  * @since 1.7
  */

--- a/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/AutoRedirectingWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
@@ -53,7 +53,6 @@ import org.junit.runners.Parameterized;
  * Test case for {@link BasicAuthWire}.
  *
  * @version $Id$
- * @author Jakob Oswald (jakob.oswald@gmx.net)
  * @since 1.17.1
  */
 @RunWith(Parameterized.class)

--- a/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
@@ -48,7 +48,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Test case for {@link BasicAuthWire}.
@@ -73,7 +72,9 @@ public final class BasicAuthWireTest {
     /**
      * The charset to use.
      */
-    private static final Charset CHARSET = Charset.forName(ENCODING);
+    private static final Charset CHARSET = Charset.forName(
+        BasicAuthWireTest.ENCODING
+    );
 
     /**
      * The username to use for authentication.
@@ -103,7 +104,7 @@ public final class BasicAuthWireTest {
      * @return The username and password parameters used to construct
      *  the test
      */
-    @Parameters
+    @Parameterized.Parameters
     public static Collection<Object[]> getParameters() {
         final Collection<Object[]> parameters = new ArrayList<>(10);
         parameters.add(new String[] {"Alice", "secret"});
@@ -124,12 +125,12 @@ public final class BasicAuthWireTest {
         ).start();
         final URI uri = UriBuilder.fromUri(container.home()).userInfo(
             String.format(
-                CRED_FORMAT,
-                URLEncoder.encode(this.username, ENCODING),
-                URLEncoder.encode(this.password, ENCODING)
+                BasicAuthWireTest.CRED_FORMAT,
+                URLEncoder.encode(this.username, BasicAuthWireTest.ENCODING),
+                URLEncoder.encode(this.password, BasicAuthWireTest.ENCODING)
             )
         ).build();
-        final String expected = expectHeader(
+        final String expected = BasicAuthWireTest.expectHeader(
             this.username,
             this.password
         );
@@ -158,10 +159,10 @@ public final class BasicAuthWireTest {
         final String password) {
         final String credentials = DatatypeConverter.printBase64Binary(
             String.format(
-                CRED_FORMAT,
+                BasicAuthWireTest.CRED_FORMAT,
                 username,
                 password
-            ).getBytes(CHARSET)
+            ).getBytes(BasicAuthWireTest.CHARSET)
         );
         return String.format("Basic %s", credentials);
     }

--- a/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
@@ -129,7 +129,7 @@ public final class BasicAuthWireTest {
                 URLEncoder.encode(this.password, ENCODING)
             )
         ).build();
-        final String expectedHeader = expectHeader(
+        final String expected = expectHeader(
             this.username,
             this.password
         );
@@ -141,7 +141,7 @@ public final class BasicAuthWireTest {
         container.stop();
         MatcherAssert.assertThat(
             container.take().headers().get(HttpHeaders.AUTHORIZATION).get(0),
-            Matchers.equalTo(expectedHeader)
+            Matchers.equalTo(expected)
         );
     }
 

--- a/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
@@ -52,7 +52,6 @@ import org.junit.runners.Parameterized;
 /**
  * Test case for {@link BasicAuthWire}.
  *
- * @version $Id$
  * @since 1.17.1
  */
 @RunWith(Parameterized.class)

--- a/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/BasicAuthWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/CachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CachingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link CachingWire}.
- * @version $Id$
  * @since 1.0
  */
 public final class CachingWireTest {

--- a/src/test/java/com/jcabi/http/wire/CachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CachingWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/CachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CachingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link CachingWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link CookieOptimizingWire}.
- * @version $Id$
  * @since 1.0
  */
 public final class CookieOptimizingWireTest {

--- a/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CookieOptimizingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link CookieOptimizingWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link ETagCachingWire}.
- * @author Ievgen Degtiarenko (ievgen.degtiarenko@gmail.com)
  * @version $Id$
  * @since 2.0
  */

--- a/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link ETagCachingWire}.
- * @version $Id$
  * @since 2.0
  */
 public final class ETagCachingWireTest {

--- a/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/ETagCachingWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/FcWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/FcWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FcWire}.
- * @version $Id$
  * @since 1.0
  */
 public final class FcWireTest {

--- a/src/test/java/com/jcabi/http/wire/FcWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/FcWireTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FcWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/wire/FcWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/FcWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link LastModifiedCachingWire}.
- * @version $Id$
  * @since 1.15
  */
 public final class LastModifiedCachingWireTest {

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -124,7 +124,9 @@ public final class LastModifiedCachingWireTest {
             final Request req = new JdkRequest(container.home())
                 .through(LastModifiedCachingWire.class);
             for (int idx = 0; idx < Tv.TEN; ++idx) {
-                req.fetch().as(RestResponse.class)
+                req
+                    .fetch()
+                    .as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)
@@ -237,14 +239,20 @@ public final class LastModifiedCachingWireTest {
         try {
             final Request req = new JdkRequest(container.home())
                 .through(LastModifiedCachingWire.class);
-            req.fetch().as(RestResponse.class)
+            req
+                .fetch()
+                .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
                     Matchers.equalTo(body)
                 );
-            req.fetch().as(RestResponse.class)
+            req
+                .fetch()
+                .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
-            req.fetch().as(RestResponse.class)
+            req
+                .fetch()
+                .as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
                     Matchers.equalTo(body)
@@ -286,14 +294,18 @@ public final class LastModifiedCachingWireTest {
             final Request req = new JdkRequest(container.home())
                 .through(LastModifiedCachingWire.class);
             for (int idx = 0; idx < 2; ++idx) {
-                req.fetch().as(RestResponse.class)
+                req
+                    .fetch()
+                    .as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)
                     );
             }
             for (int idx = 0; idx < 2; ++idx) {
-                req.fetch().as(RestResponse.class)
+                req
+                    .fetch()
+                    .as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(
@@ -335,7 +347,9 @@ public final class LastModifiedCachingWireTest {
                     "Fri, 01 Jan 2016 00:00:00 GMT"
                 );
             for (int idx = 0; idx < 2; ++idx) {
-                req.fetch().as(RestResponse.class)
+                req
+                    .fetch()
+                    .as(RestResponse.class)
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link LastModifiedCachingWire}.
- * @author Igor Piddubnyi (igor.piddubnyi@gmail.com)
  * @version $Id$
  * @since 1.15
  */

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/LastModifiedCachingWireTest.java
@@ -128,7 +128,7 @@ public final class LastModifiedCachingWireTest {
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)
-                );
+                    );
             }
             MatcherAssert.assertThat(
                 container.queries(), Matchers.equalTo(Tv.TEN)
@@ -241,14 +241,14 @@ public final class LastModifiedCachingWireTest {
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
                     Matchers.equalTo(body)
-            );
+                );
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_NOT_FOUND);
             req.fetch().as(RestResponse.class)
                 .assertStatus(HttpURLConnection.HTTP_OK)
                 .assertBody(
                     Matchers.equalTo(body)
-            );
+                );
         } finally {
             container.stop();
         }
@@ -290,7 +290,7 @@ public final class LastModifiedCachingWireTest {
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)
-                );
+                    );
             }
             for (int idx = 0; idx < 2; ++idx) {
                 req.fetch().as(RestResponse.class)
@@ -299,7 +299,7 @@ public final class LastModifiedCachingWireTest {
                         Matchers.equalTo(
                             LastModifiedCachingWireTest.BODY_UPDATED
                         )
-                );
+                    );
             }
             MatcherAssert.assertThat(
                 container.queries(), Matchers.equalTo(2 + 2)
@@ -308,6 +308,7 @@ public final class LastModifiedCachingWireTest {
             container.stop();
         }
     }
+
     /**
      * LastModifiedCachingWire can send a request directly
      * if it contains the "If-Modified-Since" header.
@@ -338,7 +339,7 @@ public final class LastModifiedCachingWireTest {
                     .assertStatus(HttpURLConnection.HTTP_OK)
                     .assertBody(
                         Matchers.equalTo(LastModifiedCachingWireTest.BODY)
-                );
+                    );
             }
             MatcherAssert.assertThat(container.queries(), Matchers.equalTo(2));
         } finally {
@@ -351,7 +352,9 @@ public final class LastModifiedCachingWireTest {
      * @return The query matcher
      */
     private static Matcher<MkQuery> queryContainsIfModifiedSinceHeader() {
-        return queryContainingHeader("If-Modified-Since");
+        return LastModifiedCachingWireTest.queryContainingHeader(
+            "If-Modified-Since"
+        );
     }
 
     /**
@@ -366,6 +369,7 @@ public final class LastModifiedCachingWireTest {
             protected boolean matchesSafely(final MkQuery query) {
                 return query.headers().containsKey(header);
             }
+
             @Override
             public void describeTo(final Description description) {
                 description.appendText("contains ");

--- a/src/test/java/com/jcabi/http/wire/RetryWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/RetryWireTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RetryWire}.
- * @version $Id$
  * @since 1.2
  */
 public final class RetryWireTest {

--- a/src/test/java/com/jcabi/http/wire/RetryWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/RetryWireTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link RetryWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.2
  */

--- a/src/test/java/com/jcabi/http/wire/RetryWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/RetryWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 
 /**
  * Integration case for {@link TrustedWire}.
- * @version $Id$
  * @since 1.10.1
  */
 public final class TrustedWireITCase {

--- a/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 
 /**
  * Integration case for {@link TrustedWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.10.1
  */

--- a/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireITCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link TrustedWire}.
- * @version $Id$
  * @since 1.10
  */
 public final class TrustedWireTest {

--- a/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link TrustedWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.10
  */

--- a/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link UserAgentWire}.
- * @version $Id$
  * @since 1.2
  */
 public final class UserAgentWireTest {

--- a/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link UserAgentWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.2
  */

--- a/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/UserAgentWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * Test case for {@link VerboseWire}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 1.0
  */
 public final class VerboseWireTest {
 

--- a/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link VerboseWire}.
- * @version $Id$
  * @since 1.0
  */
 public final class VerboseWireTest {

--- a/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 /**
  * Test case for {@link VerboseWire}.
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 1.0
  */

--- a/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/VerboseWireTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *

--- a/src/test/java/com/jcabi/http/wire/package-info.java
+++ b/src/test/java/com/jcabi/http/wire/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Wires, tests.
  *
- * @version $Id$
  * @since 0.10
  */
 package com.jcabi.http.wire;

--- a/src/test/java/com/jcabi/http/wire/package-info.java
+++ b/src/test/java/com/jcabi/http/wire/package-info.java
@@ -31,7 +31,6 @@
 /**
  * Wires, tests.
  *
- * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.10
  */

--- a/src/test/java/com/jcabi/http/wire/package-info.java
+++ b/src/test/java/com/jcabi/http/wire/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2011-2017, jcabi.com
  * All rights reserved.
  *


### PR DESCRIPTION
This is for #171 

- Bump parent to 1.25.1 (openjdk8)
- Perform qulice penance
- Replace cobertura with jacoco
- Explicitly set dependencies of `jcabi-matchers` in order to avoid conflicts
