### PR TITLE
Provide a MkQuery matcher for the query part of the URI

### DIFF
--- a/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryMatchers.java
@@ -81,4 +81,14 @@ public final class MkQueryMatchers {
         return new MkQueryPathMatcher(path);
     }
 
+    /**
+     * Matches the query of the MkQuery.
+     *
+     * @param query The query to check.
+     * @return Matcher for checking the query of MkQuery
+     */
+    public static Matcher<MkQuery> hasQuery(final Matcher<String> query) {
+        return new MkQueryQueryMatcher(query);
+    }
+
 }

--- a/src/main/java/com/jcabi/http/mock/MkQueryQueryMatcher.java
+++ b/src/main/java/com/jcabi/http/mock/MkQueryQueryMatcher.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2017, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.http.mock;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+/**
+ * Matcher for checking {@link MkQuery#uri()} contents.
+ *
+ * @since 1.17.4
+ * @checkstyle ProtectedMethodInFinalClassCheck (50 lines)
+ */
+public final class MkQueryQueryMatcher extends TypeSafeDiagnosingMatcher<MkQuery> {
+    /**
+     * Query to match.
+     */
+    private final transient Matcher<String> query;
+
+    /**
+     * Constructor.
+     * @param qry Query to match.
+     */
+    MkQueryQueryMatcher(final Matcher<String> qry) {
+        super();
+        this.query = qry;
+    }
+
+    @Override
+    public void describeTo(final Description desc) {
+        desc.appendDescriptionOf(this.query);
+    }
+
+    @Override
+    protected boolean matchesSafely(
+        final MkQuery item, final Description desc
+    ) {
+        desc.appendText("actual query ").appendValue(item.uri().getRawQuery());
+        return this.query.matches(item.uri().getRawQuery());
+    }
+}


### PR DESCRIPTION
I contemplated making MkQueryPathMatcher also allow the checking of the query, but that seemed wrong.

Not certain whether 1.17.4 has been released, so perhaps the @since should be 1.17.5?