### PR TITLE
Issue 252 autoredirectingwire relative location fix

### DIFF
--- a/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
+++ b/src/main/java/com/jcabi/http/wire/AutoRedirectingWire.java
@@ -125,7 +125,7 @@ public final class AutoRedirectingWire implements Wire {
             }
             URI location = URI.create(locations.get(0));
             if (!location.isAbsolute()) {
-                location = uri.resolve(uri);
+                location = uri.resolve(location);
             }
             response = this.origin.send(
                 req, location.toString(),

--- a/src/test/java/com/jcabi/http/RequestITCaseTemplate.java
+++ b/src/test/java/com/jcabi/http/RequestITCaseTemplate.java
@@ -154,6 +154,15 @@ public abstract class RequestITCaseTemplate {
     }
 
     @Test
+    final void followsLocationHeaderRelativeRedirect() throws IOException {
+        this.request("/relative-redirect/5")
+            .through(AutoRedirectingWire.class, Tv.SIX)
+            .fetch()
+            .as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK);
+    }
+
+    @Test
     final void failsOnTimeout() {
         Assertions.assertThrows(
             IOException.class,


### PR DESCRIPTION
#252 AutoRedirectingWire does not work if location is relative
Changes:
AutoRedirectingWire.java - fixed code to resolve url from location in header
RequestITCaseTemplate.java - Added new test case "followsLocationHeaderRelativeRedirect"