### PR TITLE
Add TRACE and CONNECT method constants to Request (fixes #127)

### DIFF
--- a/src/main/java/com/jcabi/http/Request.java
+++ b/src/main/java/com/jcabi/http/Request.java
@@ -90,6 +90,18 @@ public interface Request {
     String PATCH = "PATCH";
 
     /**
+     * TRACE method name.
+     * @since 2.0
+     */
+    String TRACE = "TRACE";
+
+    /**
+     * CONNECT method name.
+     * @since 2.0
+     */
+    String CONNECT = "CONNECT";
+
+    /**
      * Get destination URI.
      * @return The destination it is currently pointing to
      */

--- a/src/test/java/com/jcabi/http/RequestMethodsTest.java
+++ b/src/test/java/com/jcabi/http/RequestMethodsTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2011-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.jcabi.http;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for HTTP method constants exposed by {@link Request}.
+ * @since 2.0
+ */
+final class RequestMethodsTest {
+
+    @Test
+    void exposesTraceMethodConstant() throws Exception {
+        MatcherAssert.assertThat(
+            "TRACE constant must equal \"TRACE\"",
+            RequestMethodsTest.constant("TRACE"),
+            Matchers.equalTo("TRACE")
+        );
+    }
+
+    @Test
+    void exposesConnectMethodConstant() throws Exception {
+        MatcherAssert.assertThat(
+            "CONNECT constant must equal \"CONNECT\"",
+            RequestMethodsTest.constant("CONNECT"),
+            Matchers.equalTo("CONNECT")
+        );
+    }
+
+    private static String constant(final String name) throws Exception {
+        final Field field = Request.class.getField(name);
+        final int mods = field.getModifiers();
+        MatcherAssert.assertThat(
+            String.format("%s must be public static final", name),
+            Modifier.isPublic(mods)
+                && Modifier.isStatic(mods)
+                && Modifier.isFinal(mods),
+            Matchers.is(true)
+        );
+        return (String) field.get(null);
+    }
+}


### PR DESCRIPTION
@yegor256 — this PR closes #127 by adding the two missing HTTP method constants to `com.jcabi.http.Request`.

## What changed

- `src/main/java/com/jcabi/http/Request.java` — added `String TRACE = "TRACE"` and `String CONNECT = "CONNECT"` next to the existing `GET`, `POST`, `PUT`, `HEAD`, `DELETE`, `OPTIONS`, and `PATCH` constants. Both methods are part of HTTP/1.1 (RFC 2616 §9.8 and §9.9), so the interface should expose them like the others. Each is annotated `@since 2.0`.
- `src/test/java/com/jcabi/http/RequestMethodsTest.java` — new regression test (committed before the fix) that uses reflection to assert each constant exists, is `public static final`, and equals its canonical method name. The test fails on `master` with `NoSuchFieldException` and passes after the fix.

## Why two commits

Per the task workflow I followed, the failing test was committed first (`e855f6e8`) to demonstrate the bug, then the fix (`a16290d9`).

## Verification

- `mvn -B test` — 149/149 tests pass on this branch (147/147 on master, plus the two new ones).
- `mvn -B -Pqulice verify -DskipTests` — 220 violations both before and after my changes; **no new violations are introduced** by this PR.
- The 12 failing `mvn (...)` matrix jobs and the `owasp` job fail identically on `master@HEAD` (same 220 qulice violations; OWASP needs an `NVD_API_KEY` secret that isn't exposed to fork PRs). The mvn workflow uses `continue-on-error: true` and its overall conclusion for this PR is `success`.
- All 8 lint/style checks pass (`actionlint`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`).

Closes #127