### PR TITLE
#122: bypass CachingWire on Cache-Control/Pragma no-cache

### DIFF
--- a/src/main/java/com/jcabi/http/wire/CachingWire.java
+++ b/src/main/java/com/jcabi/http/wire/CachingWire.java
@@ -11,10 +11,12 @@ import com.jcabi.aspects.Immutable;
 import com.jcabi.http.Request;
 import com.jcabi.http.Response;
 import com.jcabi.http.Wire;
+import jakarta.ws.rs.core.HttpHeaders;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -103,6 +105,23 @@ public final class CachingWire implements Wire {
     private static final String NEVER = "$never";
 
     /**
+     * Pragma HTTP header name (RFC 7234 §5.4).
+     */
+    private static final String PRAGMA = "Pragma";
+
+    /**
+     * No-cache directive value used in {@code Cache-Control}
+     * and {@code Pragma} request headers.
+     */
+    private static final String NO_CACHE = "no-cache";
+
+    /**
+     * No-store directive value used in {@code Cache-Control}
+     * request headers.
+     */
+    private static final String NO_STORE = "no-store";
+
+    /**
      * Original wire.
      */
     private final transient Wire origin;
@@ -187,7 +206,7 @@ public final class CachingWire implements Wire {
             this.cache.invalidateAll();
         }
         final Response rsp;
-        if (method.equals(Request.GET)) {
+        if (method.equals(Request.GET) && !CachingWire.bypass(headers)) {
             try {
                 rsp = this.cache.get(
                     new CachingWire.Query(
@@ -214,6 +233,42 @@ public final class CachingWire implements Wire {
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static void invalidate() {
         CachingWire.CACHE.invalidateAll();
+    }
+
+    /**
+     * Should the cache be bypassed for this request?
+     *
+     * <p>Per RFC 7234 §5.2.1, a request that carries
+     * {@code Cache-Control: no-cache} or {@code no-store} must not be
+     * served from a cached response, and a {@code no-store} request must
+     * not be stored either. {@code Pragma: no-cache} is the HTTP/1.0
+     * backwards-compatible equivalent of {@code Cache-Control: no-cache}
+     * (RFC 7234 §5.4).
+     *
+     * @param headers Request headers
+     * @return Whether the request asks the cache to be skipped
+     */
+    private static boolean bypass(
+        final Collection<Map.Entry<String, String>> headers
+    ) {
+        boolean bypass = false;
+        for (final Map.Entry<String, String> header : headers) {
+            final String name = header.getKey();
+            final String value = header.getValue()
+                .toLowerCase(Locale.ENGLISH);
+            if (HttpHeaders.CACHE_CONTROL.equals(name)
+                && (value.contains(CachingWire.NO_CACHE)
+                || value.contains(CachingWire.NO_STORE))) {
+                bypass = true;
+                break;
+            }
+            if (CachingWire.PRAGMA.equals(name)
+                && value.contains(CachingWire.NO_CACHE)) {
+                bypass = true;
+                break;
+            }
+        }
+        return bypass;
     }
 
     /**

--- a/src/test/java/com/jcabi/http/wire/CachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CachingWireTest.java
@@ -14,6 +14,7 @@ import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
+import jakarta.ws.rs.core.HttpHeaders;
 import java.net.HttpURLConnection;
 import java.util.concurrent.Callable;
 import org.hamcrest.MatcherAssert;
@@ -94,6 +95,98 @@ final class CachingWireTest {
             "should be equal 3",
             container.queries(),
             Matchers.equalTo(3)
+        );
+    }
+
+    /**
+     * CachingWire bypasses the cache on every request that carries
+     * a {@code Cache-Control: no-cache} directive (RFC 7234 §5.2.1.4),
+     * even when an identical request with the same header has already
+     * been served.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    void bypassesCacheWhenCacheControlNoCache() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(new MkAnswer.Simple("first"))
+            .next(new MkAnswer.Simple("second"))
+            .next(new MkAnswer.Simple("third"))
+            .start();
+        final Request req = new JdkRequest(container.home())
+            .through(CachingWire.class)
+            .header(HttpHeaders.CACHE_CONTROL, "no-cache");
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("first"));
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("second"));
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("third"));
+        container.stop();
+        MatcherAssert.assertThat(
+            "no-cache request must always hit origin",
+            container.queries(),
+            Matchers.equalTo(3)
+        );
+    }
+
+    /**
+     * CachingWire bypasses the cache when the request carries
+     * a {@code Cache-Control: no-store} directive (RFC 7234 §5.2.1.5).
+     * The response must not be stored in the cache either, so subsequent
+     * identical no-store requests also reach the origin.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    void bypassesCacheWhenCacheControlNoStore() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(new MkAnswer.Simple("uno"))
+            .next(new MkAnswer.Simple("dos"))
+            .start();
+        final Request req = new JdkRequest(container.home())
+            .through(CachingWire.class)
+            .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("uno"));
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("dos"));
+        container.stop();
+        MatcherAssert.assertThat(
+            "no-store request must not be served from the cache",
+            container.queries(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    /**
+     * CachingWire bypasses the cache when the request carries
+     * a {@code Pragma: no-cache} directive (RFC 7234 §5.4).
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    void bypassesCacheWhenPragmaNoCache() throws Exception {
+        final MkContainer container = new MkGrizzlyContainer()
+            .next(new MkAnswer.Simple("alpha"))
+            .next(new MkAnswer.Simple("beta"))
+            .start();
+        final Request req = new JdkRequest(container.home())
+            .through(CachingWire.class)
+            .header("Pragma", "no-cache");
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("alpha"));
+        req.fetch().as(RestResponse.class)
+            .assertStatus(HttpURLConnection.HTTP_OK)
+            .assertBody(Matchers.containsString("beta"));
+        container.stop();
+        MatcherAssert.assertThat(
+            "Pragma no-cache request must always hit origin",
+            container.queries(),
+            Matchers.equalTo(2)
         );
     }
 

--- a/src/test/java/com/jcabi/http/wire/CachingWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/CachingWireTest.java
@@ -108,22 +108,16 @@ final class CachingWireTest {
     @Test
     void bypassesCacheWhenCacheControlNoCache() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple("first"))
-            .next(new MkAnswer.Simple("second"))
-            .next(new MkAnswer.Simple("third"))
+            .next(new MkAnswer.Simple(""))
+            .next(new MkAnswer.Simple(""))
+            .next(new MkAnswer.Simple(""))
             .start();
         final Request req = new JdkRequest(container.home())
             .through(CachingWire.class)
             .header(HttpHeaders.CACHE_CONTROL, "no-cache");
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("first"));
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("second"));
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("third"));
+        for (int idx = 0; idx < 3; ++idx) {
+            req.fetch();
+        }
         container.stop();
         MatcherAssert.assertThat(
             "no-cache request must always hit origin",
@@ -142,18 +136,14 @@ final class CachingWireTest {
     @Test
     void bypassesCacheWhenCacheControlNoStore() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple("uno"))
-            .next(new MkAnswer.Simple("dos"))
+            .next(new MkAnswer.Simple(""))
+            .next(new MkAnswer.Simple(""))
             .start();
         final Request req = new JdkRequest(container.home())
             .through(CachingWire.class)
             .header(HttpHeaders.CACHE_CONTROL, "no-store");
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("uno"));
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("dos"));
+        req.fetch();
+        req.fetch();
         container.stop();
         MatcherAssert.assertThat(
             "no-store request must not be served from the cache",
@@ -170,18 +160,14 @@ final class CachingWireTest {
     @Test
     void bypassesCacheWhenPragmaNoCache() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
-            .next(new MkAnswer.Simple("alpha"))
-            .next(new MkAnswer.Simple("beta"))
+            .next(new MkAnswer.Simple(""))
+            .next(new MkAnswer.Simple(""))
             .start();
         final Request req = new JdkRequest(container.home())
             .through(CachingWire.class)
             .header("Pragma", "no-cache");
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("alpha"));
-        req.fetch().as(RestResponse.class)
-            .assertStatus(HttpURLConnection.HTTP_OK)
-            .assertBody(Matchers.containsString("beta"));
+        req.fetch();
+        req.fetch();
         container.stop();
         MatcherAssert.assertThat(
             "Pragma no-cache request must always hit origin",


### PR DESCRIPTION
@yegor256 this closes #122.

`CachingWire` cached every successful GET indefinitely and ignored the standard request directives that ask the cache to be skipped. The wire now honours, on every request, the headers defined in RFC 7234:

- `Cache-Control: no-cache` &mdash; always reach the origin (RFC 7234 §5.2.1.4)
- `Cache-Control: no-store` &mdash; reach the origin and do not store the response (RFC 7234 §5.2.1.5)
- `Pragma: no-cache` &mdash; HTTP/1.0 alias of `no-cache` (RFC 7234 §5.4)

The new private helper `CachingWire#bypass(headers)` walks the request headers, lowercases each value, and matches `no-cache` / `no-store` against `Cache-Control` and `no-cache` against `Pragma`. The substring match deliberately tolerates compound directives like `no-cache, max-age=0`. When the helper returns `true`, `send` skips the Guava cache lookup and routes the request straight to the origin wire, so the response is never read from the cache and never stored.

## Commits

1. `468cd37` &mdash; three failing regression tests in `CachingWireTest` exercising each directive.
2. `c81c78b` &mdash; the fix in `CachingWire`, plus a small refactor of the new tests so they keep the file's existing single-`assertThat` style.

## Test plan

- [x] Three new tests:
  - `bypassesCacheWhenCacheControlNoCache` &mdash; three identical `no-cache` GETs reach the origin three times.
  - `bypassesCacheWhenCacheControlNoStore` &mdash; two identical `no-store` GETs reach the origin twice (response not stored).
  - `bypassesCacheWhenPragmaNoCache` &mdash; two identical `Pragma: no-cache` GETs reach the origin twice.
- [x] Pre-existing `CachingWireTest` tests still green (`cachesGetRequest`, `ignoresPutRequest`, `flushesOnRegularExpressionMatch`, `cachesGetRequestWithCustomCache`).
- [x] Full unit-test suite green: `mvn test` &rarr; 152/152.
- [x] `mvn -Pqulice -DskipTests` violation count is unchanged vs. master HEAD (`5bcfc8f`): 220 &rarr; 220 &mdash; this PR adds no new lint violations.

## CI status

The matrix `mvn` jobs and `owasp` are pre-existing failures on master HEAD `5bcfc8f`; they fail identically on this branch with the same output and unchanged violation count. The `mvn` workflow itself concludes `success` thanks to `continue-on-error: true`, exactly as on master. All other workflows (`pdd`, `reuse`, `typos`, `xcop`, `yamllint`, `markdown-lint`, `copyrights`, `actionlint`) are green.