### PR TITLE
#177 Add regression test for RestResponse.assertBody body-only assertion

### DIFF
--- a/src/test/java/com/jcabi/http/RequestTest.java
+++ b/src/test/java/com/jcabi/http/RequestTest.java
@@ -709,6 +709,34 @@ final class RequestTest extends RequestTestTemplate {
     }
 
     /**
+     * RestResponse.assertBody matches only the response body, not HTTP headers.
+     * Reproduces https://github.com/jcabi/jcabi-http/issues/177
+     * @param type Request type
+     * @throws Exception If something goes wrong inside
+     */
+    @Values
+    @ParameterizedTest
+    void assertBodyMatchesOnlyBodyNotHttpHeaders(
+        final Class<? extends Request> type
+    ) throws Exception {
+        final String expected = "hello";
+        final MkContainer container = new MkGrizzlyContainer().next(
+            new MkAnswer.Simple(expected)
+        ).start();
+        try {
+            RequestTestTemplate.request(container.home(), type)
+                .method(Request.POST)
+                .body().set("request").back()
+                .fetch().as(RestResponse.class)
+                .assertBody(
+                    Matchers.equalTo(expected)
+                );
+        } finally {
+            container.stop();
+        }
+    }
+
+    /**
      * Content type stream.
      * @return Content type header.
      */


### PR DESCRIPTION
## Summary

- Closes #177
- Adds `assertBodyMatchesOnlyBodyNotHttpHeaders` — a parameterised test (runs with both `JdkRequest` and `ApacheRequest`) that uses `Matchers.equalTo` (strict equality) to verify that `RestResponse.assertBody` matches *only* the response body, not the full HTTP response string including headers
- The existing `assertsHttpResponseBody` test used `Matchers.containsString`, which would not catch a regression where `body()` inadvertently returns headers + body

## Root cause analysis

The underlying `RestResponse.assertBody` method has always correctly passed `this.body()` as the actual value to `MatcherAssert.assertThat` rather than `this.toString()` (the full response). The original reporter reproduced the issue via the `takes` framework's `FtRemote` test infrastructure; the current implementation is correct for `JdkRequest` and `ApacheRequest` backed by `MkGrizzlyContainer`. Adding this strict-equality regression test prevents any future regression.

## Test plan

- [ ] `mvn test` passes locally (154 tests, 0 failures) including both parameterized variants of the new test
- [ ] CI green on this PR

https://claude.ai/code/session_01GNwvSETBzmbc573V3gPenJ