### PR TITLE
Fix #202: TrustedWire now sets SSLContext.getDefault() so ApacheRequest trusts all certificates

### DIFF
--- a/src/main/java/com/jcabi/http/request/ApacheRequest.java
+++ b/src/main/java/com/jcabi/http/request/ApacheRequest.java
@@ -39,9 +39,6 @@ import org.apache.http.util.EntityUtils;
  * <p>The class is immutable and thread-safe.
  *
  * @since 0.8
- * @todo #200:30m TrustedWire does not support ApacheRequest.
- *  Investigate if it's possible for them to work together,
- *  if not see jcabi-http#178 for discussion about alternative solutions.
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 @Immutable
@@ -64,12 +61,13 @@ public final class ApacheRequest implements Request {
             final InputStream content,
             final int connect,
             final int read) throws IOException {
-            try (CloseableHttpResponse response = HttpClients.createSystem().execute(
-                this.httpRequest(
-                    home, method, headers, content,
-                    connect, read
-                )
-            )) {
+            try (CloseableHttpResponse response = HttpClients.createSystem()
+                .execute(
+                    this.httpRequest(
+                        home, method, headers, content,
+                        connect, read
+                    )
+                )) {
                 return new DefaultResponse(
                     req,
                     response.getStatusLine().getStatusCode(),

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -89,14 +89,7 @@ public final class TrustedWire implements Wire {
             final SSLSocketFactory def =
                 HttpsURLConnection.getDefaultSSLSocketFactory();
             final SSLContext ctx = TrustedWire.context();
-            final SSLContext defctx;
-            try {
-                defctx = SSLContext.getDefault();
-            } catch (final NoSuchAlgorithmException ex) {
-                throw new IOException(
-                    "Failed to obtain default SSL context", ex
-                );
-            }
+            final SSLContext defctx = TrustedWire.defaultContext();
             try {
                 HttpsURLConnection.setDefaultSSLSocketFactory(
                     ctx.getSocketFactory()
@@ -110,6 +103,18 @@ public final class TrustedWire implements Wire {
                 HttpsURLConnection.setDefaultSSLSocketFactory(def);
                 SSLContext.setDefault(defctx);
             }
+        }
+    }
+
+    /**
+     * Get the current default SSL context, wrapping any checked exception.
+     * @return Default SSL context
+     */
+    private static SSLContext defaultContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
         }
     }
 

--- a/src/main/java/com/jcabi/http/wire/TrustedWire.java
+++ b/src/main/java/com/jcabi/http/wire/TrustedWire.java
@@ -88,16 +88,27 @@ public final class TrustedWire implements Wire {
         synchronized (TrustedWire.class) {
             final SSLSocketFactory def =
                 HttpsURLConnection.getDefaultSSLSocketFactory();
+            final SSLContext ctx = TrustedWire.context();
+            final SSLContext defctx;
+            try {
+                defctx = SSLContext.getDefault();
+            } catch (final NoSuchAlgorithmException ex) {
+                throw new IOException(
+                    "Failed to obtain default SSL context", ex
+                );
+            }
             try {
                 HttpsURLConnection.setDefaultSSLSocketFactory(
-                    TrustedWire.context().getSocketFactory()
+                    ctx.getSocketFactory()
                 );
+                SSLContext.setDefault(ctx);
                 return this.origin.send(
                     req, home, method, headers, content,
                     connect, read
                 );
             } finally {
                 HttpsURLConnection.setDefaultSSLSocketFactory(def);
+                SSLContext.setDefault(defctx);
             }
         }
     }

--- a/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
@@ -7,9 +7,16 @@ package com.jcabi.http.wire;
 import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
+import com.jcabi.http.request.FakeRequest;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
+import java.io.ByteArrayInputStream;
 import java.net.HttpURLConnection;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import javax.net.ssl.SSLContext;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,6 +43,46 @@ final class TrustedWireTest {
         } finally {
             container.stop();
         }
+    }
+
+    /**
+     * TrustedWire must change the default SSL context during send so that
+     * Apache HTTP client (used by ApacheRequest) also trusts all certificates.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    void setsDefaultSslContextDuringSendForApacheHttpClientCompatibility()
+        throws Exception {
+        final SSLContext before = SSLContext.getDefault();
+        final SSLContext[] during = {null};
+        new TrustedWire(
+            (req, home, method, headers, content, connect, read) -> {
+                try {
+                    during[0] = SSLContext.getDefault();
+                } catch (final NoSuchAlgorithmException ex) {
+                    throw new java.io.IOException(ex);
+                }
+                return new FakeRequest().fetch();
+            }
+        ).send(
+            new FakeRequest(),
+            "https://localhost/",
+            "GET",
+            Collections.emptyList(),
+            new ByteArrayInputStream(new byte[0]),
+            0,
+            0
+        );
+        MatcherAssert.assertThat(
+            "TrustedWire must replace the default SSL context during send",
+            during[0],
+            Matchers.not(Matchers.sameInstance(before))
+        );
+        MatcherAssert.assertThat(
+            "TrustedWire must restore the default SSL context after send",
+            SSLContext.getDefault(),
+            Matchers.sameInstance(before)
+        );
     }
 
 }

--- a/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
+++ b/src/test/java/com/jcabi/http/wire/TrustedWireTest.java
@@ -4,16 +4,22 @@
  */
 package com.jcabi.http.wire;
 
+import com.jcabi.http.Request;
+import com.jcabi.http.Response;
+import com.jcabi.http.Wire;
 import com.jcabi.http.mock.MkAnswer;
 import com.jcabi.http.mock.MkContainer;
 import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.FakeRequest;
 import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.RestResponse;
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import javax.net.ssl.SSLContext;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -46,43 +52,87 @@ final class TrustedWireTest {
     }
 
     /**
-     * TrustedWire must change the default SSL context during send so that
-     * Apache HTTP client (used by ApacheRequest) also trusts all certificates.
+     * TrustedWire must replace SSLContext.getDefault() during send so
+     * that Apache HTTP client (HttpClients.createSystem()) also trusts
+     * all certificates when ApacheRequest is the underlying wire.
      * @throws Exception If something goes wrong inside
      */
     @Test
-    void setsDefaultSslContextDuringSendForApacheHttpClientCompatibility()
-        throws Exception {
+    void replacesDefaultSslContextDuringSend() throws Exception {
         final SSLContext before = SSLContext.getDefault();
-        final SSLContext[] during = {null};
-        new TrustedWire(
-            (req, home, method, headers, content, connect, read) -> {
-                try {
-                    during[0] = SSLContext.getDefault();
-                } catch (final NoSuchAlgorithmException ex) {
-                    throw new java.io.IOException(ex);
-                }
-                return new FakeRequest().fetch();
-            }
-        ).send(
+        final SslContextCapture capture = new SslContextCapture();
+        new TrustedWire(capture).send(
             new FakeRequest(),
             "https://localhost/",
             "GET",
             Collections.emptyList(),
-            new ByteArrayInputStream(new byte[0]),
+            InputStream.nullInputStream(),
             0,
             0
         );
         MatcherAssert.assertThat(
             "TrustedWire must replace the default SSL context during send",
-            during[0],
+            capture.captured(),
             Matchers.not(Matchers.sameInstance(before))
+        );
+    }
+
+    /**
+     * TrustedWire must restore SSLContext.getDefault() after send completes.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    void restoresDefaultSslContextAfterSend() throws Exception {
+        final SSLContext before = SSLContext.getDefault();
+        new TrustedWire(new SslContextCapture()).send(
+            new FakeRequest(),
+            "https://localhost/",
+            "GET",
+            Collections.emptyList(),
+            InputStream.nullInputStream(),
+            0,
+            0
         );
         MatcherAssert.assertThat(
             "TrustedWire must restore the default SSL context after send",
             SSLContext.getDefault(),
             Matchers.sameInstance(before)
         );
+    }
+
+    /**
+     * Wire that captures SSLContext.getDefault() at the moment send() runs.
+     * @since 1.10
+     */
+    private static final class SslContextCapture implements Wire {
+
+        /**
+         * The SSLContext captured during send.
+         */
+        private volatile SSLContext captured;
+
+        @Override
+        // @checkstyle ParameterNumber (5 lines)
+        public Response send(final Request req, final String home,
+            final String method,
+            final Collection<Map.Entry<String, String>> headers,
+            final InputStream content,
+            final int connect, final int read) throws IOException {
+            try {
+                this.captured = SSLContext.getDefault();
+            } catch (final NoSuchAlgorithmException ex) {
+                throw new IOException(ex);
+            }
+            return new FakeRequest().fetch();
+        }
+
+        /**
+         * The SSLContext that was active when send() ran.
+         * @return Captured context
+         */
+        SSLContext captured() {
+            return this.captured;
+        }
     }
 
 }


### PR DESCRIPTION
TrustedWire.send() was calling HttpsURLConnection.setDefaultSSLSocketFactory() only, which affects JdkRequest but has no effect on ApacheRequest. Apache HTTP client's HttpClients.createSystem() builds its SSL configuration from SSLContext.getDefault(), so the trust-all context was silently ignored when ApacheRequest was the underlying wire.

The fix adds SSLContext.setDefault(ctx) alongside the existing HttpsURLConnection change, saves the original default in the same synchronized block, and restores it in the finally block. The existing ignoresPkixErrors unit test continues to pass, and a new test (setsDefaultSslContextDuringSendForApacheHttpClientCompatibility) confirms that SSLContext.getDefault() is replaced during send and restored afterwards.

Closes #202