### PR TITLE
#258 decode gzip and deflate responses in JdkRequest

### DIFF
--- a/src/main/java/com/jcabi/http/request/JdkRequest.java
+++ b/src/main/java/com/jcabi/http/request/JdkRequest.java
@@ -25,7 +25,10 @@ import java.net.URLConnection;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -153,7 +156,8 @@ public final class JdkRequest implements Request {
             }
             byte[] body = new byte[0];
             if (inp != null) {
-                try (InputStream is = inp; ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+                try (InputStream is = this.decode(inp, conn.getContentEncoding());
+                    ByteArrayOutputStream os = new ByteArrayOutputStream()) {
                     final byte[] buffer = new byte[8192];
                     int bytes;
                     while (true) {
@@ -167,6 +171,32 @@ public final class JdkRequest implements Request {
                 }
             }
             return body;
+        }
+
+        /**
+         * Wrap the response stream in a decoder when the server set
+         * {@code Content-Encoding} to {@code gzip} or {@code deflate}.
+         * @param raw Raw response stream
+         * @param encoding Value of the {@code Content-Encoding} header, may be {@code null}
+         * @return Stream that yields the decoded payload
+         * @throws IOException If wrapping fails
+         */
+        private InputStream decode(final InputStream raw, final String encoding)
+            throws IOException {
+            final InputStream out;
+            if (encoding == null) {
+                out = raw;
+            } else {
+                final String normalized = encoding.trim().toLowerCase(Locale.ENGLISH);
+                if ("gzip".equals(normalized) || "x-gzip".equals(normalized)) {
+                    out = new GZIPInputStream(raw);
+                } else if ("deflate".equals(normalized)) {
+                    out = new InflaterInputStream(raw);
+                } else {
+                    out = raw;
+                }
+            }
+            return out;
         }
     };
 

--- a/src/test/java/com/jcabi/http/RequestITCaseTemplate.java
+++ b/src/test/java/com/jcabi/http/RequestITCaseTemplate.java
@@ -4,7 +4,6 @@
  */
 package com.jcabi.http;
 
-import com.jcabi.http.request.JdkRequest;
 import com.jcabi.http.response.JsonResponse;
 import com.jcabi.http.response.RestResponse;
 import com.jcabi.http.response.XmlResponse;
@@ -26,7 +25,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -162,7 +160,6 @@ public abstract class RequestITCaseTemplate {
     }
 
     @Test
-    @DisabledIf("isJdkRequest")
     final void readsDeflatedJsonResponse() throws Exception {
         MatcherAssert.assertThat(
             "Must undeflate & parse Json response",
@@ -179,7 +176,6 @@ public abstract class RequestITCaseTemplate {
     }
 
     @Test
-    @DisabledIf("isJdkRequest")
     final void readsGzippedJsonResponse() throws Exception {
         MatcherAssert.assertThat(
             "Must unzip & parse Json response",
@@ -223,14 +219,5 @@ public abstract class RequestITCaseTemplate {
                 .xml(),
             Matchers.notNullValue(XML.class)
         );
-    }
-
-    /**
-     * Is JdkRequest being tested?
-     * @return True if so.
-     */
-    @SuppressWarnings("PMD.UnusedPrivateMethod")
-    private boolean isJdkRequest() {
-        return JdkRequest.class.equals(this.type);
     }
 }


### PR DESCRIPTION
Closes #258

`JdkRequest`'s inner `WIRE` used to hand the raw `HttpURLConnection.getInputStream()` straight to `body()`, so any response carrying `Content-Encoding: gzip` or `deflate` reached the caller still encoded — exactly what issue #258 reports against httpbin's `/gzip` and `/deflate` endpoints. The `WIRE.body` method now inspects `conn.getContentEncoding()` and wraps the stream in `GZIPInputStream` for `gzip`/`x-gzip` or `InflaterInputStream` for `deflate` before draining it, so the returned `byte[]` is the decoded payload. Other encodings (or a missing header) fall through to the raw stream. The two integration tests in `RequestITCaseTemplate` that exercise `/gzip` and `/deflate` no longer carry `@DisabledIf("isJdkRequest")`, and the now-unused helper is removed.

Checks run locally on this branch: `mvn compile` and `mvn test-compile` pass; `mvn test` runs the 156 unit tests with `Tests run: 156, Failures: 0, Errors: 0, Skipped: 0`. A short standalone driver against `https://httpbin.org/gzip` and `https://httpbin.org/deflate` returned the decoded JSON bodies (`{"gzipped": true, ...}` and `{"deflated": true, ...}`) end to end. The dockerized integration suite that runs the now-enabled tests requires Docker, which is not available in this sandbox; CI will exercise them.
